### PR TITLE
Change all "target" userId parameters to "userId"

### DIFF
--- a/examples/cleanPlayers.js
+++ b/examples/cleanPlayers.js
@@ -50,31 +50,31 @@ rbx.setCookie(cookie)
     }
 
     const groupRoles = await rbx.getRoles(getRolesOptions)
-    const targetRoles = []
+    const userIdRoles = []
 
     for (const role of groupRoles) {
       if (options.roleset.includes(role.id)) {
-        targetRoles.push(role)
+        userIdRoles.push(role)
       }
 
-      if (targetRoles.length === options.roleset.length) {
+      if (userIdRoles.length === options.roleset.length) {
         break
       }
     }
 
-    if (targetRoles.length === 0) {
+    if (userIdRoles.length === 0) {
       console.error('No roles matching the roleset IDs were found.')
 
       return
     }
 
-    options.roleset = targetRoles.map((role) => {
+    options.roleset = userIdRoles.map((role) => {
       return role.id
     })
 
     let totalPlayers = 0
 
-    for (const role of targetRoles) {
+    for (const role of userIdRoles) {
       totalPlayers += role.memberCount
     }
 
@@ -112,7 +112,7 @@ rbx.setCookie(cookie)
       if (shouldExile(player)) {
         const exileOptions = {
           group: options.group,
-          target: player.userId
+          userId: player.userId
         }
 
         rbx.exile(exileOptions)

--- a/examples/cleanPlayers.js
+++ b/examples/cleanPlayers.js
@@ -50,31 +50,31 @@ rbx.setCookie(cookie)
     }
 
     const groupRoles = await rbx.getRoles(getRolesOptions)
-    const userIdRoles = []
+    const targetRoles = []
 
     for (const role of groupRoles) {
       if (options.roleset.includes(role.id)) {
-        userIdRoles.push(role)
+        targetRoles.push(role)
       }
 
-      if (userIdRoles.length === options.roleset.length) {
+      if (targetRoles.length === options.roleset.length) {
         break
       }
     }
 
-    if (userIdRoles.length === 0) {
+    if (targetRoles.length === 0) {
       console.error('No roles matching the roleset IDs were found.')
 
       return
     }
 
-    options.roleset = userIdRoles.map((role) => {
+    options.roleset = targetRoles.map((role) => {
       return role.id
     })
 
     let totalPlayers = 0
 
-    for (const role of userIdRoles) {
+    for (const role of targetRoles) {
       totalPlayers += role.memberCount
     }
 

--- a/lib/group/changeRank.js
+++ b/lib/group/changeRank.js
@@ -4,7 +4,7 @@ const getRoles = require('./getRoles.js').func
 const getRankNameInGroup = require('./getRankNameInGroup.js').func
 
 // Args
-exports.required = ['group', 'target', 'change']
+exports.required = ['group', 'userId', 'change']
 exports.optional = ['jar']
 
 // Docs
@@ -13,7 +13,7 @@ exports.optional = ['jar']
  * @category Group
  * @alias changeRank
  * @param {number} groupId - The id of the group.
- * @param {number} target - The userId of the target.
+ * @param {number} userId - The userId of the user having their rank changed.
  * @param {number} change - The change in rank (1 = one rank higher, -1 = one rank lower)
  * @returns {Promise<ChangeRankResult>}
  * @example const noblox = require("noblox.js")
@@ -24,10 +24,10 @@ exports.optional = ['jar']
 // Define
 exports.func = function (args) {
   const group = args.group
-  const target = args.target
+  const userId = args.userId
   const amount = args.change
   const jar = args.jar
-  return getRankNameInGroup({ group: group, userId: target })
+  return getRankNameInGroup({ group: group, userId: userId })
     .then(function (rank) {
       if (rank === 'Guest') {
         throw new Error('Target user is not in group')
@@ -48,7 +48,7 @@ exports.func = function (args) {
                 throw new Error('Group members cannot be demoted to guest.')
               }
 
-              return setRank({ group: group, target: target, rank: found.id, jar: jar })
+              return setRank({ group: group, userId: userId, rank: found.id, jar: jar })
                 .then(function () {
                   return { newRole: found, oldRole: role }
                 })

--- a/lib/group/demote.js
+++ b/lib/group/demote.js
@@ -2,7 +2,7 @@
 const changeRank = require('./changeRank.js').func
 
 // Args
-exports.required = ['group', 'target']
+exports.required = ['group', 'userId']
 exports.optional = ['jar']
 
 // Docs
@@ -11,7 +11,7 @@ exports.optional = ['jar']
  * @category Group
  * @alias demote
  * @param {number} group - The id of the group.
- * @param {number} target - The userId of the user being demoted.
+ * @param {number} userId - The userId of the user being demoted.
  * @returns {Promise<ChangeRankResult>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/group/exile.js
+++ b/lib/group/exile.js
@@ -3,7 +3,7 @@ const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
 
 // Args
-exports.required = ['group', 'target']
+exports.required = ['group', 'userId']
 exports.optional = ['jar']
 
 // Docs
@@ -12,17 +12,17 @@ exports.optional = ['jar']
  * @category Group
  * @alias exile
  * @param {number} group - The id of the group.
- * @param {number} target - The userId of the user being exiled.
+ * @param {number} userId - The userId of the user being exiled.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * noblox.exile(1, 2)
 **/
 
-function exileUser (group, target, jar, xcsrf) {
+function exileUser (group, userId, jar, xcsrf) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
-      url: `https://groups.roblox.com/v1/groups/${group}/users/${target}`,
+      url: `https://groups.roblox.com/v1/groups/${group}/users/${userId}`,
       options: {
         method: 'DELETE',
         resolveWithFullResponse: true,
@@ -54,6 +54,6 @@ exports.func = function (args) {
   const jar = args.jar
   return getGeneralToken({ jar: jar })
     .then(function (xcsrf) {
-      return exileUser(args.group, args.target, args.jar, xcsrf)
+      return exileUser(args.group, args.userId, args.jar, xcsrf)
     })
 }

--- a/lib/group/promote.js
+++ b/lib/group/promote.js
@@ -2,7 +2,7 @@
 const changeRank = require('./changeRank.js').func
 
 // Args
-exports.required = ['group', 'target']
+exports.required = ['group', 'userId']
 exports.optional = ['jar']
 
 // Docs
@@ -11,7 +11,7 @@ exports.optional = ['jar']
  * @category Group
  * @alias promote
  * @param {number} group - The id of the group.
- * @param {number} target - The id of the user.
+ * @param {number} userId - The id of the user being promoted.
  * @returns {Promise<ChangeRankResult>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/group/setRank.js
+++ b/lib/group/setRank.js
@@ -4,7 +4,7 @@ const getGeneralToken = require('../util/getGeneralToken.js').func
 const getRole = require('./getRole.js').func
 
 // Args
-exports.required = ['group', 'target', 'rank']
+exports.required = ['group', 'userId', 'rank']
 exports.optional = ['jar']
 
 // Docs
@@ -13,7 +13,7 @@ exports.optional = ['jar']
  * @category Group
  * @alias setRank
  * @param {number} group - The id of the group.
- * @param {number} target - The id of the user whose rank is being changed.
+ * @param {number} userId - The id of the user whose rank is being changed.
  * @param {number | string | Role} rank - The rank, roleset ID, name of the role, or the actual Role itself.
  * @returns {Promise<Role>}
  * @example const noblox = require("noblox.js")
@@ -22,10 +22,10 @@ exports.optional = ['jar']
 **/
 
 // Define
-function setRank (jar, xcsrf, group, target, role) {
+function setRank (jar, xcsrf, group, userId, role) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
-      url: `//groups.roblox.com/v1/groups/${group}/users/${target}`,
+      url: `//groups.roblox.com/v1/groups/${group}/users/${userId}`,
       options: {
         resolveWithFullResponse: true,
         method: 'PATCH',
@@ -60,7 +60,7 @@ function runWithToken (args) {
   const jar = args.jar
   return getGeneralToken({ jar: jar })
     .then(function (xcsrf) {
-      return setRank(jar, xcsrf, args.group, args.target, args.role)
+      return setRank(jar, xcsrf, args.group, args.userId, args.role)
     })
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1287,9 +1287,9 @@ declare module "noblox.js" {
     /// Group
 
     /**
-     * Moves the user with userId `target` up or down the list of ranks in `group` by `change`. For example `changeRank(group, target, 1)` would promote the user 1 rank and `changeRank(group, target, -1)` would demote them down 1. Note that this simply follows the list, ignoring ambiguous ranks. The full `newRole` as well as the user's original `oldRole` is returned.
+     * Moves the user with the given userId up or down the list of ranks in `group` by `change`. For example `changeRank(group, userId, 1)` would promote the user 1 rank and `changeRank(group, userId, -1)` would demote them down 1. Note that this simply follows the list, ignoring ambiguous ranks. The full `newRole` as well as the user's original `oldRole` is returned.
      */
-    function changeRank(group: number, target: number, change: number, jar?: CookieJar): Promise<ChangeRankResult>;
+    function changeRank(group: number, userId: number, change: number, jar?: CookieJar): Promise<ChangeRankResult>;
 
     /**
      * Deletes the wall post with `id` in `group`. If `page` is known it can be inserted to speed up finding the post, otherwise it will search for the post. Alternatively `post` can be passed in, which only has to contain `view` and `parent.index` to work properly. Using `post` will be much faster because it will not have to search for the post first.
@@ -1297,14 +1297,14 @@ declare module "noblox.js" {
     function deleteWallPost(group: number, post: number | WallPost, page?: number, jar?: CookieJar): Promise<void>;
 
     /**
-     * Alias of `changeRank(group, target, -1)`.
+     * Alias of `changeRank(group, userId, -1)`.
      */
-    function demote(group: number, target: number, jar?: CookieJar): Promise<ChangeRankResult>;
+    function demote(group: number, userId: number, jar?: CookieJar): Promise<ChangeRankResult>;
 
     /**
-     * Exiles user with `userId` target from `group`.
+     * Exiles user with the given userId from the given group.
      */
-    function exile(group: number, target: number, jar?: CookieJar): Promise<void>;
+    function exile(group: number, userId: number, jar?: CookieJar): Promise<void>;
 
     /**
      * Performs a payout in group with the groupId `group`. If `recurring` is true this will configure the recurring options for the group's payout replacing all old values, otherwise a one-time-payout is made. To clear the recurring payouts, pass in empty arrays to both member and amount. Argument `member` can either be a single userId or an array of userIds. If it is a single value `amount` must be as well, otherwise `amount` has to be a parallel array of equal length. If `usePercentage` is true `amount` percentage of the total group funds is paid to the members, otherwise it pays `amount` ROBUX. Note that recurring payouts are always percentages, and when `recurring` is true `usePercentage` is ignored.
@@ -1327,14 +1327,14 @@ declare module "noblox.js" {
     function leaveGroup(group: number, jar?: CookieJar): Promise<void>;
 
     /**
-     * Alias of `changeRank(group, target, 1)`.
+     * Alias of `changeRank(group, userId, 1)`.
      */
-    function promote(group: number, target: number, jar?: CookieJar): Promise<ChangeRankResult>;
+    function promote(group: number, userId: number, jar?: CookieJar): Promise<ChangeRankResult>;
 
     /**
-     * Changes the rank of the player with the `target` userId in group with `groupId` to the provided rank. If rank <= 255, it is assumes to be rank. If rank is a string, it is assumed to be the name of a rank/role. If rank is > 255, it is assumed to be a rolesetId (which speeds up requests). If two or more ranks share a rank, this will not resolve properly (use the name of the rank instead). You may also pass a Role which can be gotten from `getRoles` or `getRole`.
+     * Changes the rank of the player with the given userId in group with `groupId` to the provided rank. If rank <= 255, it is assumes to be rank. If rank is a string, it is assumed to be the name of a rank/role. If rank is > 255, it is assumed to be a rolesetId (which speeds up requests). If two or more ranks share a rank, this will not resolve properly (use the name of the rank instead). You may also pass a Role which can be gotten from `getRoles` or `getRole`.
      */
-    function setRank(group: number, target: number, rank: number | string | Role, jar?: CookieJar): Promise<Role>;
+    function setRank(group: number, userId: number, rank: number | string | Role, jar?: CookieJar): Promise<Role>;
 
     /**
      * Shouts message `message` in the group with groupId `group`. Setting `message` to "" will clear the shout.


### PR DESCRIPTION
Many of the group functions take either "target" or "userId" as their parameter name for userId. This creates confusion on the documentation. An example of this is getRankInGroup(group, userId), which has its userId parameter labeled "userId", while setRank(group, target, rank) has it's userId parameter labeled "target". This is an unnecessary dual labeling when it is the same parameter, and should be fixed.