### PR TITLE
Implement getGroupGames()

### DIFF
--- a/lib/group/getGroupGames.js
+++ b/lib/group/getGroupGames.js
@@ -11,9 +11,9 @@ exports.optional = ['accessFilter', 'sortOrder', 'limit']
  * @category Group
  * @alias getGroupGames
  * @param {number} groupId - The id of the group.
- * @param {("All" | "Public" | "Private")} accessFilter - Filtering games via access level.
- * @param {("Asc" | "Desc")} sortOrder - The order results are sorted in.
- * @param {Limit=} [limit=10] - The maximum results per page (10, 25, 50, or 100).
+ * @param {("All" | "Public" | "Private")=} [accessFilter=All] - Filtering games via access level.
+ * @param {SortOrder=} [sortOrder=Asc] - The order results are sorted in.
+ * @param {Limit=} [limit=∞] - The maximum number of games to return
  * @returns {Promise<GroupGameInfo[]>}
  * @example const noblox = require("noblox.js")
  * const groupGames = await noblox.getGroupGames({groupId: 1, accessFilter: 'All', sortOrder: 'Asc', limit: '100'})
@@ -23,8 +23,8 @@ exports.optional = ['accessFilter', 'sortOrder', 'limit']
 exports.func = function (args) {
   return getPageResults({
     url: `//games.roblox.com/v2/groups/${args.groupId}/games`,
-    accessFilter: args.accessFilter || 'All',
+    query: { accessFilter: args.accessFilter || 'All' },
     sortOrder: args.sortOrder || 'Asc',
-    limit: args.limit || 10
+    limit: args.limit
   })
 }

--- a/lib/group/getGroupGames.js
+++ b/lib/group/getGroupGames.js
@@ -1,0 +1,30 @@
+// Includes
+const getPageResults = require('../util/getPageResults.js').func
+
+// Args
+exports.required = ['groupId']
+exports.optional = ['accessFilter', 'sortOrder', 'limit']
+
+// Docs
+/**
+ * Get a group's games.
+ * @category Group
+ * @alias getGroupGames
+ * @param {number} groupId - The id of the group.
+ * @param {("All" | "Public" | "Private")} accessFilter - Filtering games via access level.
+ * @param {("Asc" | "Desc")} sortOrder - The order results are sorted in.
+ * @param {Limit=} [limit=10] - The maximum results per page (10, 25, 50, or 100).
+ * @returns {Promise<GroupGameInfo[]>}
+ * @example const noblox = require("noblox.js")
+ * const groupGames = await noblox.getGroupGames({groupId: 1, accessFilter: 'All', sortOrder: 'Asc', limit: '100'})
+**/
+
+// Define
+exports.func = function (args) {
+  return getPageResults({
+    url: `//games.roblox.com/v2/groups/${args.groupId}/games`,
+    accessFilter: args.accessFilter || 'All',
+    sortOrder: args.sortOrder || 'Asc',
+    limit: args.limit || 10
+  })
+}

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -1,4 +1,4 @@
-const { changeRank, getAuditLog, getGroup, getGroupFunds, getGroupTransactions, getJoinRequests, getLogo, getPlayers, getRankInGroup, getRankNameInGroup, getRole, getRolePermissions, getRoles, getShout, getWall, setRank, shout, setCookie } = require('../lib')
+const { changeRank, getAuditLog, getGroup, getGroupFunds, getGroupGames, getGroupTransactions, getJoinRequests, getLogo, getPlayers, getRankInGroup, getRankNameInGroup, getRole, getRolePermissions, getRoles, getShout, getWall, setRank, shout, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -108,6 +108,27 @@ describe('Group Methods', () => {
   it('getGroupFunds() returns amount of robux in group funds', () => {
     return getGroupFunds(9997719).then((res) => {
       return expect(res).toEqual(expect.any(Number))
+    })
+  })
+
+  it('getGroupGames() returns an array of group games', () => {
+    return getGroupGames({ groupId: 2629410, limit: 1 }).then((res) => { // FIXME: Convert to noblox.js groupId, currently Roblox broke the creation of group games during the experience rebranding
+      return expect(res[0]).toMatchObject({
+        id: expect.any(Number),
+        name: expect.any(String),
+        description: expect.any(String),
+        creator: {
+          id: expect.any(Number),
+          type: expect.any(String)
+        },
+        rootPlace: {
+          id: expect.any(Number),
+          type: expect.any(String)
+        },
+        created: expect.any(Date),
+        updated: expect.any(Date),
+        placeVisits: expect.any(Number)
+      })
     })
   })
 

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -112,7 +112,7 @@ describe('Group Methods', () => {
   })
 
   it('getGroupGames() returns an array of group games', () => {
-    return getGroupGames({ groupId: 2629410, limit: 1 }).then((res) => { // FIXME: Convert to noblox.js groupId, currently Roblox broke the creation of group games during the experience rebranding
+    return getGroupGames({ groupId: 9997719, limit: 1 }).then((res) => {
       return expect(res[0]).toMatchObject({
         id: expect.any(Number),
         name: expect.any(String),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -39,6 +39,17 @@ declare module "noblox.js" {
         IsPrimary: boolean,
     }
 
+    interface GroupGameInfo {
+        id: number;
+        name: string;
+        description: string | null;
+        creator: {id: number; type: string;};
+        rootPlace: {id: number; type: string;};
+        created: Date;
+        updated: Date;
+        placeVisits: number;
+    }
+
     interface ProductInfo {
         AssetId: number;
         ProductId: number;
@@ -1355,6 +1366,11 @@ declare module "noblox.js" {
      * Gets a brief overview of the specified group.
      */
     function getGroup(groupId: number): Promise<Group>;
+
+    /**
+     * Gets a list of games from the specified group.
+     */
+    function getGroupGames(groupId: number, acccessFilter: "All" | "Public" | "Private", sortOrder: "Asc" | "Desc", limit: Limit, cursor: string): Promise<GroupGameInfo[]>;
 
     /**
      * Gets the groups a player is in.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,9 +42,9 @@ declare module "noblox.js" {
     interface GroupGameInfo {
         id: number;
         name: string;
-        description: string | null;
-        creator: {id: number; type: string;};
-        rootPlace: {id: number; type: string;};
+        description?: string;
+        creator: { id: number; type: string; };
+        rootPlace: { id: number; type: string; };
         created: Date;
         updated: Date;
         placeVisits: number;
@@ -60,22 +60,22 @@ declare module "noblox.js" {
         IconImageAssetId: number;
         Created: Date;
         Updated: Date;
-        PriceInRobux: number | null;
-        PriceInTickets: number | null;
+        PriceInRobux?: number;
+        PriceInTickets?: number;
         Sales: number;
         IsNew: boolean;
         IsForSale: boolean;
         IsPublicDomain: boolean;
         IsLimited: boolean;
         IsLimitedUnique: boolean;
-        Remaining: number | null;
+        Remaining?: number;
         MinimumMembershipLevel: number;
         ContentRatingTypeId: number;
     }
 
     interface BuyProductInfo {
         ProductId: number;
-        Creator: {Id: number};
+        Creator: { Id: number };
         PriceInRobux: number;
         UserAssetId: number;
     }
@@ -930,7 +930,7 @@ declare module "noblox.js" {
     interface PlayerThumbnailData {
         targetId: number;
         state: "Completed" | "Pending" | "Blocked";
-        imageUrl: string | null;
+        imageUrl?: string;
     }
 
     /// Badges
@@ -961,9 +961,9 @@ declare module "noblox.js" {
     interface PlayerBadges {
         id: number;
         name: string;
-        description: string | null;
+        description?: string;
         displayName: string;
-        displayDescription: string | null;
+        displayDescription?: string;
         enabled: boolean;
         iconImageId: number;
         displayIconImageId: number;
@@ -977,9 +977,9 @@ declare module "noblox.js" {
     interface BadgeInfo {
         id: number;
         name: string;
-        description: string | null;
+        description?: string;
         displayName: string;
-        displayDescription: string | null;
+        displayDescription?: string;
         enabled: boolean;
         iconImageId: number;
         displayIconImageId: number;
@@ -1108,7 +1108,7 @@ declare module "noblox.js" {
     interface HttpOptions
     {
         verification?: string;
-        jar?: CookieJar | null;
+        jar?: CookieJar;
     }
 
     interface ThreadedPromise extends Promise<void>

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -38,15 +38,15 @@ type ProductInfo = {
     IconImageAssetId: number;
     Created: Date;
     Updated: Date;
-    PriceInRobux: number | null;
-    PriceInTickets: number | null;
+    PriceInRobux?: number;
+    PriceInTickets?: number;
     Sales: number;
     IsNew: boolean;
     IsForSale: boolean;
     IsPublicDomain: boolean;
     IsLimited: boolean;
     IsLimitedUnique: boolean;
-    Remaining: number | null;
+    Remaining?: number;
     MinimumMembershipLevel: number;
     ContentRatingTypeId: number;
 }
@@ -1226,9 +1226,9 @@ type BadgeUniverse = {
 type PlayerBadges = {
     id: number;
     name: string;
-    description: string|null;
+    description?: string;
     displayName: string;
-    displayDescription: string|null;
+    displayDescription?: string;
     enabled: boolean;
     iconImageId: number;
     displayIconImageId: number;
@@ -1245,9 +1245,9 @@ type PlayerBadges = {
 type BadgeInfo = {
     id: number;
     name: string;
-    description: string|null;
+    description?: string;
     displayName: string;
-    displayDescription: string|null;
+    displayDescription?: string;
     enabled: boolean;
     iconImageId: number;
     displayIconImageId: number;
@@ -1434,7 +1434,7 @@ type GetVerificationResponse = {
 */
 type HttpOptions = {
     verification?: string;
-    jar?: CookieJar | null;
+    jar?: CookieJar;
 }
 
 /**

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -780,7 +780,7 @@ type Group = {
 type GroupGameInfo = {
     id: number;
     name: string;
-    description: string | null;
+    description: string;
     creator: {id: number; type: string;};
     rootPlace: {id: number; type: string;};
     created: Date;

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -777,6 +777,20 @@ type Group = {
 /**
  * @typedef
  */
+type GroupGameInfo = {
+    id: number;
+    name: string;
+    description: string | null;
+    creator: {id: number; type: string;};
+    rootPlace: {id: number; type: string;};
+    created: Date;
+    updated: Date;
+    placeVisits: number;
+}
+
+/**
+ * @typedef
+ */
 type IGroupPartial = {
     Name: string;
     Id: number;


### PR DESCRIPTION
**This is a duplicated fork of #312, but has a readable commit/file history, and has some logic errors fixed.**

~~**NOTE:** A test case was added, but currently it has to point to one of my test groups instead of `noblox.js` as some reason all new games I try to create become personal games instead of group games.. possibly a symptom of their experience/game rushed rebranding.~~ Test now uses the `noblox.js` test group.

Screenshot of the function working:

![image](https://user-images.githubusercontent.com/34300238/119435693-ae70e180-bce8-11eb-833e-64db56b06270.png)

![image](https://user-images.githubusercontent.com/34300238/119438510-5d63ec00-bcee-11eb-8d18-ed6ea083c18e.png)

