### PR TITLE
Implement getGroupRevenueSummary()

### DIFF
--- a/lib/group/getGroupRevenueSummary.js
+++ b/lib/group/getGroupRevenueSummary.js
@@ -1,0 +1,46 @@
+// Includes
+const http = require('../util/http.js').func
+
+// Args
+exports.required = ['groupId']
+exports.optional = ['timeFrame', 'jar']
+
+// Docs
+/**
+ * Gets recent Robux revenue summary for a group; shows pending Robux. | Requires "Spend group funds" permissions.
+ * @category Group
+ * @alias getGroupRevenueSummary
+ * @param {number} groupId - The group id to get Robux summary for.
+ * @param {("Day" | "Week" | "Month" | "Year")=} [timeFrame="Month"] - The time frame to get for.
+ * @returns {Promise<RevenueSummaryResponse>}
+ * @example const noblox = require("noblox.js")
+ * // Login using your cookie
+ * let revenueSummary = await noblox.getGroupRevenueSummary(9997719, "Year")
+**/
+
+// Define
+function getGroupRevenueSummary (group, timeFrame, jar) {
+  return http({
+    url: `//economy.roblox.com/v1/groups/${group}/revenue/summary/${timeFrame}`,
+    options: {
+      jar: jar,
+      resolveWithFullResponse: true
+    }
+  })
+    .then(({ statusCode, body }) => {
+      const { errors } = JSON.parse(body)
+      if (statusCode === 200) {
+        return JSON.parse(body)
+      } else if (statusCode === 400 || statusCode === 401) {
+        throw new Error(`${errors[0].message} | groupId: ${group}, timeFrame: ${timeFrame}`)
+      } else if (statusCode === 403) {
+        throw new Error('Insufficient permissions: "Spend group funds" role permissions required')
+      } else {
+        throw new Error(`An unknown error occurred with getGroupFunds() | [${statusCode}] groupId: ${group}, timeFrame: ${timeFrame}`)
+      }
+    })
+}
+
+exports.func = function ({ groupId, timeFrame = 'Month', jar }) {
+  return getGroupRevenueSummary(groupId, timeFrame, jar)
+}

--- a/lib/group/getGroupRevenueSummary.js
+++ b/lib/group/getGroupRevenueSummary.js
@@ -31,8 +31,10 @@ function getGroupRevenueSummary (group, timeFrame, jar) {
       const { errors } = JSON.parse(body)
       if (statusCode === 200) {
         return JSON.parse(body)
-      } else if (statusCode === 400 || statusCode === 401) {
+      } else if (statusCode === 400) {
         throw new Error(`${errors[0].message} | groupId: ${group}, timeFrame: ${timeFrame}`)
+      } else if (statusCode === 401) {
+        throw new Error(`${errors[0].message} (Are you logged in?) | groupId: ${group}, timeFrame: ${timeFrame}`)
       } else if (statusCode === 403) {
         throw new Error('Insufficient permissions: "Spend group funds" role permissions required')
       } else {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -727,6 +727,17 @@ declare module "noblox.js" {
         data: GroupJoinRequest[];
     }
 
+    interface RevenueSummaryResponse
+    {
+        recurringRobuxStipend?: number;
+        itemSaleRobux?: number;
+        purchasedRobux?: number;
+        tradeSystemRobux?: number;
+        pendingRobux?: number;
+        groupPayoutRobux?: number;
+        individualToGroupRobux?: number;
+    }
+
     interface WallPost
     {
         id: number;
@@ -1315,6 +1326,11 @@ declare module "noblox.js" {
      * Gets the amount of robux in a group.
      */
     function getGroupFunds(group: number): Promise<number>;
+
+    /**
+     * Gets recent Robux revenue summary for a group; shows pending Robux. | Requires "Spend group funds" permissions.
+     */
+    function getGroupRevenueSummary(group: number, timeFrame?: "Day" | "Week" | "Month" | "Year"): Promise<RevenueSummaryResponse>;
 
     /**
      * `Accepts user with `username` into `group`. Note that `username` is case-sensitive.

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -919,6 +919,19 @@ type GroupJoinRequestsPage = {
 
 /**
  * @typedef
+ */
+type RevenueSummaryResponse = {
+    recurringRobuxStipend?: number;
+    itemSaleRobux?: number;
+    purchasedRobux?: number;
+    tradeSystemRobux?: number;
+    pendingRobux?: number;
+    groupPayoutRobux?: number;
+    individualToGroupRobux?: number;
+}
+
+/**
+ * @typedef
 */
 type WallPost = {
     id: number;


### PR DESCRIPTION
Closes issue #333.

I have omitted a Jest test case since the method requires `Spend group funds` permissions which cannot be given to Guest users.

Default `timeFrame` is set to `Month`, as Robux takes two weeks to pend, thus `Month` is the most likely to be used.

![image](https://user-images.githubusercontent.com/34300238/119767229-7a322800-be84-11eb-8aa9-08c16515e5d4.png)
