### PR TITLE
Convert field bracketed arrays to type generics for JSDocs compatibility

### DIFF
--- a/lib/asset/uploadModel.js
+++ b/lib/asset/uploadModel.js
@@ -12,10 +12,10 @@ exports.optional = ['itemOptions', 'asset', 'jar']
  * @category Assets
  * @alias uploadModel
  * @param {string | Stream} data - The model data.
- * @param {Object=} itemOptions - The options for the upload.
+ * @param {object=} itemOptions - The options for the upload.
  * @param {string=} itemOptions.name - The name of the model.
  * @param {string=} itemOptions.description - The description for the model.
- * @param {boolean=} itemOptions.copyLocked - If the model is copylocked.
+ * @param {boolean=} itemOptions.copyLocked - If the model is copy-locked.
  * @param {boolean=} itemOptions.allowComments - If comments are allowed.
  * @param {number=} itemOptions.groupId - The group to upload the model to.
  * @param {number=} assetId - An existing assetId to overwrite.

--- a/lib/avatar/avatarRules.js
+++ b/lib/avatar/avatarRules.js
@@ -7,7 +7,7 @@ exports.optional = ['option', 'jar']
  * ✅ Get the avatar rules.
  * @category Avatar
  * @alias avatarRules
- * @param {String=} option - A specific rule to filter for.
+ * @param {string=} option - A specific rule to filter for.
  * @returns {Promise<AvatarRules>}
  * @example const noblox = require("noblox.js")
  * const avatarRules = await noblox.avatarRules()

--- a/lib/avatar/setWearingAssets.js
+++ b/lib/avatar/setWearingAssets.js
@@ -9,7 +9,7 @@ exports.optional = ['jar']
  * 🔐 Set the assets your avatar is wearing.
  * @category Avatar
  * @alias setWearingAssets
- * @param {Array} assetIds - An array of asset IDs to wear.
+ * @param {Array<number>} assetIds - An array of asset IDs to wear.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/badges/getAwardedTimestamps.js
+++ b/lib/badges/getAwardedTimestamps.js
@@ -10,7 +10,7 @@ exports.required = ['userId', 'badgeId']
  * @category Badges
  * @alias getAwardedTimestamps
  * @param {number} userId - The userId of the user.
- * @param {Array} badgeId - The ids of the badges.
+ * @param {Array<number>} badgeId - The ids of the badges.
  * @returns {Promise<UserBadgeStats>}
  * @example const noblox = require("noblox.js")
  * const badges = await noblox.getAwardedTimestamps(1, [1, 2, 3])

--- a/lib/chat/addUsersToConversation.js
+++ b/lib/chat/addUsersToConversation.js
@@ -10,7 +10,7 @@ exports.optional = ['jar']
  * @category Chat
  * @alias addUsersToConversation
  * @param {number} conversationId - The id of the conversation.
- * @param {Array} userIds - The userIds of the users to add.
+ * @param {Array<number>} userIds - The userIds of the users to add.
  * @returns {Promise<ConversationAddResponse>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/chat/getConversations.js
+++ b/lib/chat/getConversations.js
@@ -8,7 +8,7 @@ exports.optional = ['jar']
  * 🔐 Add users to a conversation.
  * @category Chat
  * @alias getConversations
- * @param {Array} conversationIds - An array with the ids of the conversations.
+ * @param {Array<number>} conversationIds - An array with the ids of the conversations.
  * @returns {Promise<ChatConversation[]>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/chat/getRolloutSettings.js
+++ b/lib/chat/getRolloutSettings.js
@@ -7,7 +7,7 @@ exports.optional = ['featureNames', 'jar']
  * 🔐 Get the rollout settings.
  * @category Chat
  * @alias getRolloutSettings
- * @param {Array=} featureNames - The names of the features rollingout.
+ * @param {Array<string>=} featureNames - The names of the features rolling out.
  * @returns {Promise<GetRolloutSettingsResult>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/chat/getUnreadMessages.js
+++ b/lib/chat/getUnreadMessages.js
@@ -8,7 +8,7 @@ exports.optional = ['pageSize', 'jar']
  * 🔐 Returns unread messages in the given conversations
  * @category Chat
  * @alias getUnreadMessages
- * @param {number[]} conversationIds - The IDs of the conversations you want unread messages from.
+ * @param {Array<number>} conversationIds - The IDs of the conversations you want unread messages from.
  * @param {number} pageSize - Number of messages to return on each page.
  * @returns {Promise<ChatConversationWithMessages[]>}
  * @example const noblox = require("noblox.js")

--- a/lib/chat/markChatAsSeen.js
+++ b/lib/chat/markChatAsSeen.js
@@ -9,7 +9,7 @@ exports.optional = ['jar']
  * 🔐 Mark chats as seen.
  * @category Chat
  * @alias markChatAsSeen
- * @param {Array} conversationIds - An array with conversationIds.
+ * @param {Array<number>} conversationIds - An array with conversationIds.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/chat/multiGetLatestMessages.js
+++ b/lib/chat/multiGetLatestMessages.js
@@ -8,7 +8,7 @@ exports.optional = ['pageSize', 'jar']
  * 🔐 Get multiple of the latest messages.
  * @category Chat
  * @alias multiGetLatestMessages
- * @param {Array} conversationIds - An array with the conversationIds.
+ * @param {Array<number>} conversationIds - An array with the conversationIds.
  * @returns {Promise<ChatConversationWithMessages[]>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/chat/startGroupConversation.js
+++ b/lib/chat/startGroupConversation.js
@@ -9,7 +9,7 @@ exports.optional = ['jar']
  * 🔐 Start a group conversation.
  * @category Chat
  * @alias startGroupConversation
- * @param {Array} userIds - An array of userIds to add.
+ * @param {Array<number>} userIds - An array of userIds to add.
  * @param {string} title - The title of the group.
  * @returns {Promise<StartGroupConversationResponse>}
  * @example const noblox = require("noblox.js")

--- a/lib/group/getPlayers.js
+++ b/lib/group/getPlayers.js
@@ -11,7 +11,7 @@ exports.optional = ['sortOrder', 'limit', 'cursor', 'jar']
  * @category Group
  * @alias getPlayers
  * @param {number} group - The id of the group.
- * @param {number | number[]} rolesetId - The roleset's id.
+ * @param {number | Array<number>} rolesetId - The roleset's id.
  * @param {SortOrder=} sortOrder - The order to get the players in.
  * @param {Limit=} limit - The maximum result per a page.
  * @param {string=} cursor - The cursor for the next page.

--- a/lib/group/getRole.js
+++ b/lib/group/getRole.js
@@ -14,8 +14,8 @@ exports.optional = []
  * ✅ Get a role in a group.
  * @category Group
  * @alias getRole
- * @param {number | Array} group - The ID of the group or an array of roles to query.
- * @param {number | String} roleQuery - The rank of a role, the name of the role, or roleset ID.
+ * @param {number | Array<number>} group - The ID of the group or an array of roles to query.
+ * @param {number | string} roleQuery - The rank of a role, the name of the role, or roleset ID.
  * @returns {Promise<Role>}
  * @example const noblox = require("noblox.js")
  * const customerRole = await noblox.getRole(1, "Customer")

--- a/lib/group/groupPayout.js
+++ b/lib/group/groupPayout.js
@@ -12,7 +12,7 @@ exports.optional = ['recurring', 'usePercentage', 'jar']
  * @category Group
  * @alias groupPayout
  * @param {number} group - The id of the group.
- * @param {number | Array} member - The member or array of members to payout.
+ * @param {number | Array<number>} member - The member or array of members to payout.
  * @param {number} amount - The amount of Robux for each recipient to receive.
  * @param {boolean=} [recurring=false] - If the payment is recurring.
  * @param {boolean=} [usePercentage=false] - If the amount is a percentage.

--- a/lib/presence/getPresences.js
+++ b/lib/presence/getPresences.js
@@ -11,7 +11,7 @@ exports.optional = []
  * 🔐 Get the presence status of users.
  * @category Presence
  * @alias getPresences
- * @param {Array} userIds - An array of userIds.
+ * @param {Array<number>} userIds - An array of userIds.
  * @returns {Promise<Presences>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/trade/acceptTrade.js
+++ b/lib/trade/acceptTrade.js
@@ -11,7 +11,7 @@ exports.optional = ['jar']
  * 🔐 Accept an active trade.
  * @category Trade
  * @alias acceptTrade
- * @param {Number} tradeId - The tradeId to accept.
+ * @param {number} tradeId - The tradeId to accept.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/trade/canTradeWith.js
+++ b/lib/trade/canTradeWith.js
@@ -10,7 +10,7 @@ exports.optional = ['jar']
  * 🔐 Check if the signed in user can trade with another user.
  * @category Trade
  * @alias canTradeWith
- * @param {Number} userId - The id of the user.
+ * @param {number} userId - The id of the user.
  * @returns {Promise<CanTradeResponse>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/trade/counterTrade.js
+++ b/lib/trade/counterTrade.js
@@ -12,8 +12,8 @@ exports.optional = ['jar']
  * 🔐 Counter an active incoming trade.
  * @category Trade
  * @alias counterTrade
- * @param {Number} tradeId - The id of the active trade
- * @param {Number} targetUserId - The user to send the trade to.
+ * @param {number} tradeId - The id of the active trade
+ * @param {number} targetUserId - The user to send the trade to.
  * @param {TradeOffer} sendingOffer - The offer to send to the other user.
  * @param {TradeOffer} recievingOffer - The offer you are requesting from the other user.
  * @returns {Promise<SendTradeResponse>}

--- a/lib/trade/declineTrade.js
+++ b/lib/trade/declineTrade.js
@@ -11,7 +11,7 @@ exports.optional = ['jar']
  * 🔐 Decline an active trade.
  * @category Trade
  * @alias declineTrade
- * @param {Number} tradeId - The tradeId to decline.
+ * @param {number} tradeId - The tradeId to decline.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/trade/getTradeInfo.js
+++ b/lib/trade/getTradeInfo.js
@@ -10,7 +10,7 @@ exports.optional = ['jar']
  * 🔐 Get detailed information for a specific trade.
  * @category Trade
  * @alias getTradeInfo
- * @param {Number} tradeId - The id of the trade.
+ * @param {number} tradeId - The id of the trade.
  * @returns {Promise<TradeInfo>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie

--- a/lib/trade/getTrades.js
+++ b/lib/trade/getTrades.js
@@ -10,7 +10,7 @@ exports.optional = ['sortOrder', 'limit', 'jar']
  * 🔐 Get the trades for a specific category.
  * @category Trade
  * @alias getTrades
- * @param {String} tradeStatusType - The status of the trades to get [Inbound, Outbound, Complete, Inactive].
+ * @param {string} tradeStatusType - The status of the trades to get [Inbound, Outbound, Complete, Inactive].
  * @param {SortOrder=} [sortOrder=Asc] - The order that the data will be returned in (Asc or Desc)
  * @param {Limit=} [limit=10] - The number of assets returned in each request (10, 25, 50, or 100)
  * @returns {Promise<TradeAsset[]>}

--- a/lib/trade/sendTrade.js
+++ b/lib/trade/sendTrade.js
@@ -12,7 +12,7 @@ exports.optional = ['jar']
  * 🔐 Send a trade to another user.
  * @category Trade
  * @alias sendTrade
- * @param {Number} targetUserId - The user to send the trade to.
+ * @param {number} targetUserId - The user to send the trade to.
  * @param {TradeOffer} sendingOffer - The offer to send to the other user.
  * @param {TradeOffer} recievingOffer - The offer you are requesting from the other user.
  * @returns {Promise<SendTradeResponse>}

--- a/lib/user/getInventory.js
+++ b/lib/user/getInventory.js
@@ -12,7 +12,7 @@ exports.optional = ['sortOrder', 'limit', 'jar']
  * @category User
  * @alias getInventory
  * @param {number} userId - The id of user whose inventory is being returned.
- * @param {array} assetTypes - The types of assets being retrieved: [("Shirt", "Pants")]{@link https://developer.roblox.com/en-us/api-reference/enum/AssetType}.
+ * @param {Array<string>} assetTypes - The types of assets being retrieved: [("Shirt", "Pants")]{@link https://developer.roblox.com/en-us/api-reference/enum/AssetType}.
  * @param {SortOrder=} [sortOrder=Asc] - The order that the data will be returned in (Asc or Desc)
  * @param {Limit=} [limit=10] - The number of assets returned in each request (10, 25, 50, or 100)
  * @returns {Promise<Inventory>}

--- a/lib/user/getInventoryById.js
+++ b/lib/user/getInventoryById.js
@@ -11,7 +11,7 @@ exports.optional = ['sortOrder', 'limit', 'jar']
  * @category User
  * @alias getInventoryById
  * @param {number} userId - The id of user whose inventory is being returned.
- * @param {array} assetTypeId - The types of assets being retrieved: [(11, 12)]{@link https://developer.roblox.com/en-us/api-reference/enum/AssetType}.
+ * @param {Array<number>} assetTypeId - The types of assets being retrieved: [(11, 12)]{@link https://developer.roblox.com/en-us/api-reference/enum/AssetType}.
  * @param {SortOrder=} [sortOrder=Asc] - The order that the data will be returned in (Asc or Desc)
  * @param {Limit=} [limit=10] - The number of assets returned in each request (10, 25, 50, or 100)
  * @returns {Promise<Inventory>}

--- a/lib/user/getPlayerThumbnail.js
+++ b/lib/user/getPlayerThumbnail.js
@@ -27,7 +27,7 @@ const eligibleSizes = {
  * ✅ Get a user's thumbnail.
  * @category User
  * @alias getPlayerThumbnail
- * @param {number | array} userIds - The id or an array ids of thumbnails to be retrieved; 100
+ * @param {number | Array<number>} userIds - The id or an array ids of thumbnails to be retrieved; 100
  * @param {number | string=} [size=720x720] - The [size of the image to be returned]{@link https://noblox.js.org/thumbnailSizes.png}; defaults highest resolution
  * @param {'png' | 'jpeg'=} [format=png] - The file format of the returned thumbnails
  * @param {boolean=} [isCircular=false] - Return the circular version of the thumbnails

--- a/lib/user/getUAIDs.js
+++ b/lib/user/getUAIDs.js
@@ -11,8 +11,8 @@ exports.optional = ['exclusionList', 'jar']
  * @category User
  * @alias getUAIDs
  * @param {number} userId - The id of the user to search.
- * @param {Array} assetIds - The ids of the assets to retrieve.
- * @param {Array=} exclusionList - The UAIDs to exclude from the search.
+ * @param {Array<number>} assetIds - The ids of the assets to retrieve.
+ * @param {Array<number>=} exclusionList - The UAIDs to exclude from the search.
  * @returns {Promise<UAIDResponse>}
  * @example const noblox = require("noblox.js")
  * const UAIDInfo = await noblox.getUAIDs(80231025, [1974901902, 4255053867, 2705893733, 1532395])

--- a/lib/util/generalRequest.js
+++ b/lib/util/generalRequest.js
@@ -12,7 +12,7 @@ exports.optional = ['http', 'ignoreCache', 'getBody', 'jar']
  * @category Utility
  * @alias generalRequest
  * @param {string} url - The url to post to.
- * @param {Object} events - Form data to send with the request.
+ * @param {object} events - Form data to send with the request.
  * @param {boolean=} [ignoreCache=false] - Whether to ignore the cache or not.
  * @param {boolean=} [getBody=false] - Whether to return the original body before the POST request.
  * @param {CookieJar=} jar - The CookieJar containing the .ROBLOSECURITY cookie.

--- a/lib/util/getInputs.js
+++ b/lib/util/getInputs.js
@@ -11,7 +11,7 @@ exports.optional = ['find']
  * @category Utility
  * @alias getInputs
  * @param {string} html - The html to get the inputs from.
- * @param {Array=} find - The inputs to find on the page
+ * @param {Array<string>=} find - The inputs to find on the page
  * @returns {Inputs}
  * @example const noblox = require("noblox.js")
  * const inputs = noblox.getInputs("htmlhere")

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -28,7 +28,7 @@ request = request.defaults({
  * @category Utility
  * @alias http
  * @param {string} url - The url to request to.
- * @param {Object} options - The options to send with the request.
+ * @param {object} options - The options to send with the request.
  * @param {boolean} ignoreLoginError - If any login errors should be ignored.
  * @returns {Promise<string>}
  * @example const noblox = require("noblox.js")

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -260,7 +260,7 @@ declare module "noblox.js" {
 
     interface ConversationAddResponse
     {
-        conversationId: Number;
+        conversationId: number;
         rejectedParticipants: RejectedParticipant[];
         resultType: string;
         statusMessage: string;
@@ -268,7 +268,7 @@ declare module "noblox.js" {
 
     interface ConversationRemoveResponse
     {
-        conversationId: Number;
+        conversationId: number;
         resultType: string;
         statusMessage: string;
     }

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -5,8 +5,7 @@ import * as stream from "stream";
 /**
  * @typedef
 */
-type CookieJar =
-{
+type CookieJar = {
     session?: string;
 }
 
@@ -143,19 +142,19 @@ type BodyColorModel = {
  * @typedef
 */
 type DefaultClothingAssetLists = {
-    defaultShirtAssetIds: number[];
-    defaultPantAssetIds: number[];
+    defaultShirtAssetIds: Array<number>;
+    defaultPantAssetIds: Array<number>;
 }
 
 /**
  * @typedef
 */
 type AvatarRules = {
-    playerAvatarTypes: string[];
+    playerAvatarTypes: Array<string>;
     scales: AvatarRulesScales;
-    wearableAssetTypes: WearableAssetType[];
-    bodyColorsPalette: BodyColorModel[];
-    basicBodyColorsPalette: BodyColorModel[];
+    wearableAssetTypes: Array<WearableAssetType>;
+    bodyColorsPalette: Array<BodyColorModel>;
+    basicBodyColorsPalette: Array<BodyColorModel>;
     minimumDeltaEBodyColorDifference: number;
     proportionsAndBodyTypeEnabledForUser: boolean;
     defaultClothingAssetLists: DefaultClothingAssetLists;
@@ -167,7 +166,7 @@ type AvatarRules = {
  * @typedef
 */
 type AssetIdList = {
-    assetIds: number[];
+    assetIds: Array<number>;
 }
 
 /**
@@ -223,7 +222,7 @@ type AvatarInfo = {
     scales: AvatarScale;
     playerAvatarType: PlayerAvatarType;
     bodyColors: AvatarBodyColors;
-    assets: AvatarAsset[];
+    assets: Array<AvatarAsset>;
     defaultShirtApplied: boolean;
     defaultPantsApplied: boolean;
 }
@@ -253,7 +252,7 @@ type AssetRecentItem = {
  * @typedef
 */
 type AssetRecentItemsResult = {
-    data: AssetRecentItem[];
+    data: Array<AssetRecentItem>;
     total: number;
 }
 
@@ -263,8 +262,8 @@ type AssetRecentItemsResult = {
 type AvatarOutfitDetails = {
     id: number;
     name: string;
-    assets: AvatarAsset[];
-    bodyColors: AvatarBodyColors[];
+    assets: Array<AvatarAsset>;
+    bodyColors: Array<AvatarBodyColors>;
     scale: AvatarScale;
     playerAvatarType: PlayerAvatarType;
     isEditable: boolean;
@@ -283,7 +282,7 @@ type AvatarOutfit = {
  * @typedef
 */
 type GetOutfitsResult = {
-    data: AvatarOutfit[];
+    data: Array<AvatarOutfit>;
     total: number;
 }
 
@@ -304,8 +303,8 @@ type RejectedParticipant = {
  * @typedef
 */
 type ConversationAddResponse = {
-    conversationId: Number;
-    rejectedParticipants: RejectedParticipant[];
+    conversationId: number;
+    rejectedParticipants: Array<RejectedParticipant>;
     resultType: string;
     statusMessage: string;
 }
@@ -314,7 +313,7 @@ type ConversationAddResponse = {
  * @typedef
 */
 type ConversationRemoveResponse = {
-    conversationId: Number;
+    conversationId: number;
     resultType: string;
     statusMessage: string;
 }
@@ -334,7 +333,7 @@ type ConversationRenameResponse = {
 */
 type SendChatResponse = {
     content: string;
-    filteredForRecievers: boolean;
+    filteredForReceivers: boolean;
     messageId: string;
     sent: string;
     messageType: string;
@@ -354,7 +353,7 @@ type UpdateTypingResponse = {
 */
 type StartGroupConversationResponse = {
     conversation: ChatConversation;
-    rejectedParticipants: RejectedParticipant[];
+    rejectedParticipants: Array<RejectedParticipant>;
     resultType: string;
     statusMessage: string;
 }
@@ -382,7 +381,7 @@ type ChatMessage = {
     sent: string;
     read: boolean;
     messageType: "PlainText" | "Link" | "EventBased";
-    decorators: string[];
+    decorators: Array<string>;
     senderTargetId: number;
     content: string;
     link: ChatMessageLink;
@@ -428,7 +427,7 @@ type ChatConversation = {
     title: string;
     initiator: ChatParticipant;
     hasUnreadMessages: boolean;
-    participants: ChatParticipant[];
+    participants: Array<ChatParticipant>;
     conversationType: "OneToOneConversation" | "MultiUserConversation" | "CloudEditConversation";
     conversationTitle: ChatConversationTitle;
     lastUpdated: string;
@@ -469,7 +468,7 @@ type ChatFeatureNames = "LuaChat" | "ConversationUniverse" | "PlayTogether" | "P
  * @typedef
 */
 type GetRolloutSettingsResult = {
-    rolloutFeatures: ChatRolloutFeature[];
+    rolloutFeatures: Array<ChatRolloutFeature>;
 }
 
 /**
@@ -492,7 +491,7 @@ type GetUnreadConversationCountResult = {
 */
 type ChatConversationWithMessages = {
     conversationId: number;
-    chatMessages: ChatMessage[];
+    chatMessages: Array<ChatMessage>;
 }
 
 /**
@@ -535,7 +534,7 @@ type GameInstance = {
     ShowSlowGameMessage: boolean;
     Guid: string;
     PlaceId: number;
-    CurrentPlayers: GameInstancePlayer[];
+    CurrentPlayers: Array<GameInstancePlayer>;
     UserCanJoin: boolean;
     ShowShutdownButton: boolean;
     JoinScript: string;
@@ -550,7 +549,7 @@ type GameInstance = {
 type GameInstances = {
     PlaceId: number;
     ShowShutdownAllButton: boolean;
-    Collection: GameInstance[];
+    Collection: Array<GameInstance>;
     TotalCollectionSize: number;
 }
 
@@ -622,7 +621,7 @@ type DeveloperProduct = {
  * @typedef
  */
 type DeveloperProductsResult = {
-    DeveloperProducts: DeveloperProduct[],
+    DeveloperProducts: Array<DeveloperProduct>,
     FinalPage: boolean,
     PageSize: number
 }
@@ -854,7 +853,7 @@ type AuditItem = {
  * @typedef
 */
 type AuditPage = {
-    data: AuditItem[];
+    data: Array<AuditItem>;
     nextPageCursor?: string;
     previousPageCursor?: string;
 }
@@ -900,7 +899,7 @@ type TransactionItem = {
  * @typedef
 */
 type TransactionPage = {
-    data: TransactionItem[];
+    data: Array<TransactionItem>;
     nextPageCursor?: string;
     previousPageCursor?: string;
 }
@@ -928,7 +927,7 @@ type GroupJoinRequest = {
 type GroupJoinRequestsPage = {
     previousPageCursor?: string;
     nextPageCursor?: string;
-    data: GroupJoinRequest[];
+    data: Array<GroupJoinRequest>;
 }
 
 /**
@@ -961,7 +960,7 @@ type WallPost = {
 type WallPostPage = {
     previousPageCursor?: string;
     nextPageCursor?: string;
-    data: WallPost[];
+    data: Array<WallPost>;
 }
 
 /// Party
@@ -1045,7 +1044,7 @@ type FriendRequestEntry = {
 type FriendRequestsPage = {
     previousPageCursor?: string;
     nextPageCursor?: string;
-    data: FriendRequestEntry[];
+    data: Array<FriendRequestEntry>;
 }
 
 /**
@@ -1064,7 +1063,7 @@ type FriendEntry = {
  * @typedef
 */
 type Friends = {
-    friends: FriendEntry[];
+    friends: Array<FriendEntry>;
 }
 
 /**
@@ -1084,7 +1083,7 @@ type FollowEntry = {
 type FollowingsPage = {
     previousPageCursor?: string;
     nextPageCursor?: string;
-    data: FollowEntry[];
+    data: Array<FollowEntry>;
 }
 
 /**
@@ -1093,14 +1092,14 @@ type FollowingsPage = {
 type FollowersPage = {
     previousPageCursor?: string;
     nextPageCursor?: string;
-    data: FollowEntry[];
+    data: Array<FollowEntry>;
 }
 
 /**
  * @typedef
 */
 type PrivateMessagesPage = {
-    collection: PrivateMessage[];
+    collection: Array<PrivateMessage>;
     totalPages: number;
     totalCollectionSize: number;
     pageNumber: number;
@@ -1179,7 +1178,7 @@ type PlayerInfo = {
     friendCount?: number;
     followerCount?: number;
     followingCount?: number;
-    oldNames?: string[];
+    oldNames?: Array<string>;
     isBanned: boolean;
 }
 
@@ -1187,7 +1186,7 @@ type PlayerInfo = {
  * @typedef
 */
 type Presences = {
-    userPresences: UserPresence[];
+    userPresences: Array<UserPresence>;
 }
 
 /**
@@ -1300,7 +1299,7 @@ type CollectibleEntry = {
  * @typedef
 */
 type Collectibles = {
-    collectibles: CollectibleEntry[];
+    collectibles: Array<CollectibleEntry>;
 }
 
 /**
@@ -1321,7 +1320,7 @@ type InventoryEntry = {
  * @typedef
 */
 type Inventory = {
-    items: InventoryEntry[];
+    items: Array<InventoryEntry>;
 }
 
 ///Trading
@@ -1330,8 +1329,8 @@ type Inventory = {
  * @typedef
 */
 type UAIDResponse = {
-    uaids: number[],
-    failedIds: number[]
+    uaids: Array<number>,
+    failedIds: Array<number>
 }
 
 /**
@@ -1382,7 +1381,7 @@ type DetailedTradeAsset = {
 */
 type DetailedTradeOffer = {
     user: TradeUser,
-    userAssets: DetailedTradeAsset[],
+    userAssets: Array<DetailedTradeAsset>,
     robux: number
 }
 
@@ -1390,7 +1389,7 @@ type DetailedTradeOffer = {
  * @typedef
 */
 type TradeOffer = {
-    userAssetIds: number[],
+    userAssetIds: Array<number>,
     robux: number
 }
 
@@ -1398,7 +1397,7 @@ type TradeOffer = {
  * @typedef
 */
 type TradeInfo = {
-    offers: DetailedTradeOffer[],
+    offers: Array<DetailedTradeOffer>,
     id: number,
     user: TradeUser,
     created: Date,


### PR DESCRIPTION
JSDocs does not handle `Type[]` syntax correctly when used as a field (an object attribute or an optional function parameter).

The problematic behavior is apparent in our return types that include cursors:

![image](https://user-images.githubusercontent.com/34300238/121747067-d0ce7180-cad4-11eb-90a1-3460c33452d1.png)

`data` is an Array- _**of what?**_

Switching to `Array<Type>` syntax, JSDocs cooperates and shows that it is an array of `GroupJoinRequests` with a corresponding hyperlink:

![image](https://user-images.githubusercontent.com/34300238/121747264-230f9280-cad5-11eb-872f-74465848f763.png)

I have also fixed a number of types that were capitalized (`Number` -> `number`), and array parameters with no types defined.

Returns using bracketed syntax do not need to be changed.

---

**This pull request only affects JSDocs documentation, `index.d.ts` did not require modification.**
