### PR TITLE
Implement social link endpoints.

### DIFF
--- a/lib/game/getGameSocialLinks.js
+++ b/lib/game/getGameSocialLinks.js
@@ -3,7 +3,7 @@ const http = require('../util/http.js').func
 
 // Args
 exports.required = ['universeId']
-exports.optional = []
+exports.optional = ['jar']
 
 // Docs
 /**
@@ -35,7 +35,7 @@ function getGameSocialLinks (universeId, jar) {
       } else if (statusCode === 401) {
         throw new Error(`${errors[0].message} (Are you logged in?) | universeId: ${universeId}`)
       } else {
-        throw new Error(`An unknown error occurred with getGroupSocialLinks() | [${statusCode}] universeId: ${universeId}`)
+        throw new Error(`An unknown error occurred with getGameSocialLinks() | [${statusCode}] universeId: ${universeId}`)
       }
     })
 }

--- a/lib/game/getGameSocialLinks.js
+++ b/lib/game/getGameSocialLinks.js
@@ -1,0 +1,45 @@
+// Includes
+const http = require('../util/http.js').func
+
+// Args
+exports.required = ['universeId']
+exports.optional = []
+
+// Docs
+/**
+ * 🔐 Get the social link data associated with a game.
+ * @category Game
+ * @alias getGameSocialLinks
+ * @param {number} universeId - The universe id of the game.
+ * @returns {Promise<SocialLinkResponse[]>}
+ * @see [getPlaceInfo()](global.html#getPlaceInfo) - can be used to convert a placeId to a universeId
+ * @example const noblox = require("noblox.js")
+ * const gameSocialLinks = await noblox.getGameSocialLinks(2615802125)
+**/
+
+// Define
+function getGameSocialLinks (universeId, jar) {
+  return http({
+    url: `//games.roblox.com/v1/games/${universeId}/social-links/list`,
+    options: {
+      jar: jar,
+      resolveWithFullResponse: true
+    }
+  })
+    .then(({ statusCode, body }) => {
+      const { errors, data } = JSON.parse(body)
+      if (statusCode === 200 && data) {
+        return data
+      } else if (statusCode === 400 || statusCode === 403 || statusCode === 404) {
+        throw new Error(`${errors[0].message} | universeId: ${universeId}`)
+      } else if (statusCode === 401) {
+        throw new Error(`${errors[0].message} (Are you logged in?) | universeId: ${universeId}`)
+      } else {
+        throw new Error(`An unknown error occurred with getGroupSocialLinks() | [${statusCode}] universeId: ${universeId}`)
+      }
+    })
+}
+
+exports.func = function ({ universeId, jar }) {
+  return getGameSocialLinks(universeId, jar)
+}

--- a/lib/group/getGroupRevenueSummary.js
+++ b/lib/group/getGroupRevenueSummary.js
@@ -32,13 +32,13 @@ function getGroupRevenueSummary (group, timeFrame, jar) {
       if (statusCode === 200) {
         return JSON.parse(body)
       } else if (statusCode === 400) {
-        throw new Error(`${errors[0].message} | groupId: ${group}, timeFrame: ${timeFrame}`)
+        throw new Error(`${errors[0].message} | group: ${group}, timeFrame: ${timeFrame}`)
       } else if (statusCode === 401) {
-        throw new Error(`${errors[0].message} (Are you logged in?) | groupId: ${group}, timeFrame: ${timeFrame}`)
+        throw new Error(`${errors[0].message} (Are you logged in?) | group: ${group}, timeFrame: ${timeFrame}`)
       } else if (statusCode === 403) {
         throw new Error('Insufficient permissions: "Spend group funds" role permissions required')
       } else {
-        throw new Error(`An unknown error occurred with getGroupFunds() | [${statusCode}] groupId: ${group}, timeFrame: ${timeFrame}`)
+        throw new Error(`An unknown error occurred with getGroupRevenueSummary() | [${statusCode}] group: ${group}, timeFrame: ${timeFrame}`)
       }
     })
 }

--- a/lib/group/getGroupSocialLinks.js
+++ b/lib/group/getGroupSocialLinks.js
@@ -1,0 +1,44 @@
+// Includes
+const http = require('../util/http.js').func
+
+// Args
+exports.required = ['groupId']
+exports.optional = []
+
+// Docs
+/**
+ * 🔐 Get the social link data associated with a group.
+ * @category Group
+ * @alias getGroupSocialLinks
+ * @param {number} groupId - The id of the group.
+ * @returns {Promise<SocialLinkResponse[]>}
+ * @example const noblox = require("noblox.js")
+ * const groupSocialLinks = await noblox.getGroupSocialLinks(9997719)
+**/
+
+// Define
+function getGroupSocialLinks (groupId, jar) {
+  return http({
+    url: `//groups.roblox.com/v1/groups/${groupId}/social-links`,
+    options: {
+      jar: jar,
+      resolveWithFullResponse: true
+    }
+  })
+    .then(({ statusCode, body }) => {
+      const { errors, data } = JSON.parse(body)
+      if (statusCode === 200 && data) {
+        return data
+      } else if (statusCode === 400 || statusCode === 403 || statusCode === 404) {
+        throw new Error(`${errors[0].message} | groupId: ${groupId}`)
+      } else if (statusCode === 401) {
+        throw new Error(`${errors[0].message} (Are you logged in?) | groupId: ${groupId}`)
+      } else {
+        throw new Error(`An unknown error occurred with getGroupSocialLinks() | [${statusCode}] groupId: ${groupId}`)
+      }
+    })
+}
+
+exports.func = function ({ groupId, jar }) {
+  return getGroupSocialLinks(groupId, jar)
+}

--- a/lib/group/getGroupSocialLinks.js
+++ b/lib/group/getGroupSocialLinks.js
@@ -3,7 +3,7 @@ const http = require('../util/http.js').func
 
 // Args
 exports.required = ['groupId']
-exports.optional = []
+exports.optional = ['jar']
 
 // Docs
 /**

--- a/lib/user/getPlayerThumbnail.js
+++ b/lib/user/getPlayerThumbnail.js
@@ -32,7 +32,7 @@ const eligibleSizes = {
  * @param {'png' | 'jpeg'=} [format=png] - The file format of the returned thumbnails
  * @param {boolean=} [isCircular=false] - Return the circular version of the thumbnails
  * @param {'Body' | 'Bust' | 'Headshot'=} [cropType=Body] - The style of thumbnail that will be returned
- * @returns {Promise<playerThumbnailData[]>}
+ * @returns {Promise<PlayerThumbnailData[]>}
  * @example const noblox = require("noblox.js")
  * let thumbnail_default = await noblox.getPlayerThumbnail(2416399685)
  * let thumbnail_circHeadshot = await noblox.getPlayerThumbnail(2416399685, 420, "png", true, "Headshot")

--- a/lib/user/getUserSocialLinks.js
+++ b/lib/user/getUserSocialLinks.js
@@ -3,7 +3,7 @@ const http = require('../util/http.js').func
 
 // Args
 exports.required = ['userId']
-exports.optional = []
+exports.optional = ['jar']
 
 // Docs
 /**
@@ -32,7 +32,7 @@ function getUserSocialLinks (userId, jar) {
       } else if (statusCode === 400) {
         throw new Error(`${errors[0].message} | userId: ${userId}`)
       } else {
-        throw new Error(`An unknown error occurred with getGroupSocialLinks() | [${statusCode}] userId: ${userId}`)
+        throw new Error(`An unknown error occurred with getUserSocialLinks() | [${statusCode}] userId: ${userId}`)
       }
     })
 }

--- a/lib/user/getUserSocialLinks.js
+++ b/lib/user/getUserSocialLinks.js
@@ -1,0 +1,42 @@
+// Includes
+const http = require('../util/http.js').func
+
+// Args
+exports.required = ['userId']
+exports.optional = []
+
+// Docs
+/**
+ * 🔐 Get the social link data (promotion channels) associated with a user.
+ * @category User
+ * @alias getUserSocialLinks
+ * @param {number} userId - The id of the user.
+ * @returns {Promise<PromotionChannelsResponse>}
+ * @example const noblox = require("noblox.js")
+ * const userSocialLinks = await noblox.getUserSocialLinks(2416399685)
+**/
+
+// Define
+function getUserSocialLinks (userId, jar) {
+  return http({
+    url: `//accountinformation.roblox.com/v1/users/${userId}/promotion-channels`,
+    options: {
+      jar: jar,
+      resolveWithFullResponse: true
+    }
+  })
+    .then(({ statusCode, body }) => {
+      const { errors } = JSON.parse(body)
+      if (statusCode === 200) {
+        return JSON.parse(body)
+      } else if (statusCode === 400) {
+        throw new Error(`${errors[0].message} | userId: ${userId}`)
+      } else {
+        throw new Error(`An unknown error occurred with getGroupSocialLinks() | [${statusCode}] userId: ${userId}`)
+      }
+    })
+}
+
+exports.func = function ({ userId, jar }) {
+  return getUserSocialLinks(userId, jar)
+}

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,4 +1,4 @@
-const { addDeveloperProduct, checkDeveloperProductName, configureGamePass, getDeveloperProducts, getGameBadges, getGameInstances, getPlaceInfo, updateDeveloperProduct, setCookie } = require('../lib')
+const { addDeveloperProduct, checkDeveloperProductName, configureGamePass, getDeveloperProducts, getGameBadges, getGameInstances, getGameSocialLinks, getPlaceInfo, updateDeveloperProduct, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -36,11 +36,11 @@ describe('Game Methods', () => {
 
   it('configureGamePass() should configure a game pass', () => {
     const randomString = Date.now().toString().substr(-2)
-    return configureGamePass(13925030, `name${randomString}`, `random description`, parseInt(randomString)).then((res) => {
+    return configureGamePass(13925030, `name${randomString}`, 'random description', parseInt(randomString)).then((res) => {
       return expect(res).toMatchObject({
         gamePassId: 13925030,
         name: `name${randomString}`,
-        description: `random description`,
+        description: 'random description',
         price: parseInt(randomString),
         isForSale: true,
         iconChanged: false
@@ -78,6 +78,21 @@ describe('Game Methods', () => {
         Collection: expect.any(Array),
         TotalCollectionSize: expect.any(Number)
       })
+    })
+  })
+
+  it('getGameSocialLinks() should return social link information of a game, given universeId', () => {
+    return getGameSocialLinks(2615802125).then((res) => {
+      return expect(res).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            title: expect.any(String),
+            type: expect.any(String),
+            url: expect.any(String)
+          })
+        ])
+      )
     })
   })
 

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -1,4 +1,4 @@
-const { changeRank, getAuditLog, getGroup, getGroupFunds, getGroupGames, getGroupTransactions, getJoinRequests, getLogo, getPlayers, getRankInGroup, getRankNameInGroup, getRole, getRolePermissions, getRoles, getShout, getWall, setRank, shout, setCookie } = require('../lib')
+const { changeRank, getAuditLog, getGroup, getGroupFunds, getGroupGames, getGroupSocialLinks, getGroupTransactions, getJoinRequests, getLogo, getPlayers, getRankInGroup, getRankNameInGroup, getRole, getRolePermissions, getRoles, getShout, getWall, setRank, shout, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -129,6 +129,21 @@ describe('Group Methods', () => {
         updated: expect.any(Date),
         placeVisits: expect.any(Number)
       })
+    })
+  })
+
+  it('getGroupSocialLinks() should return social link information of a game, given universeId', () => {
+    return getGroupSocialLinks(9997719).then((res) => {
+      return expect(res).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            title: expect.any(String),
+            type: expect.any(String),
+            url: expect.any(String)
+          })
+        ])
+      )
     })
   })
 

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,4 +1,4 @@
-const { acceptFriendRequest, block, unblock, canManage, declineFriendRequest, follow, unfollow, getBlurb, getCollectibles, getFollowers, getFollowings, getFriendRequests, getFriends, getGroups, getIdFromUsername, getInventory, getInventoryById, getMessages, getOwnership, getPlayerBadges, getPlayerInfo, getPlayerThumbnail, getStatus, getUserTransactions, getUsernameFromId, removeFriend, sendFriendRequest, setCookie } = require('../lib')
+const { acceptFriendRequest, block, unblock, canManage, declineFriendRequest, follow, unfollow, getBlurb, getCollectibles, getFollowers, getFollowings, getFriendRequests, getFriends, getGroups, getIdFromUsername, getInventory, getInventoryById, getMessages, getOwnership, getPlayerBadges, getPlayerInfo, getPlayerThumbnail, getStatus, getUserSocialLinks, getUserTransactions, getUsernameFromId, removeFriend, sendFriendRequest, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -339,6 +339,17 @@ describe('User Methods', () => {
   it('getUsernameFromId() returns a player\'s username given an ID', () => {
     return getUsernameFromId(1).then((res) => {
       return expect(res).toEqual(expect.any(String))
+    })
+  })
+
+  it('getUserSocialLinks() returns a player\'s promotion channel links', () => {
+    return getUserSocialLinks(2416399685).then((res) => {
+      return expect(res).toMatchObject({
+        facebook: expect.nullOrAny(String),
+        twitter: expect.nullOrAny(String),
+        youtube: expect.nullOrAny(String),
+        twitch: expect.nullOrAny(String)
+      })
     })
   })
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -499,6 +499,13 @@ declare module "noblox.js" {
         Price: number
     }
 
+    type SocialLinkResponse = {
+        id: number;
+        type: 'Facebook' | 'Twitter' | 'YouTube' | 'Twitch' | 'GooglePlus' | 'Discord' | 'RobloxGroup' | 'Amazon';
+        url: string;
+        title: string;
+    }
+
     interface DeveloperProduct {
         ProductId: number,
         DeveloperProductId: number,
@@ -944,6 +951,13 @@ declare module "noblox.js" {
         imageUrl?: string;
     }
 
+    interface PromotionChannelsResponse {
+        facebook?: string;
+        twitter?: string;
+        youtube?: string;
+        twitch?: string;
+    }
+
     /// Badges
 
     interface BadgeAwarder {
@@ -1306,6 +1320,11 @@ declare module "noblox.js" {
     
     function configureGamePass(gamePassId: number, name: string, description?: string, price?: number | boolean, icon?: string | stream.Stream, jar?: CookieJar): Promise<GamePassResponse>;
 
+    /**
+     * 🔐 Get the social link data associated with a game.
+     */
+    function getGameSocialLinks(universeId: number, jar?: CookieJar): Promise<SocialLinkResponse[]>;
+
     /// Group
 
     /**
@@ -1372,6 +1391,11 @@ declare module "noblox.js" {
      * 🔐 Gets the audit logs of the specified group.
      */
     function getAuditLog(group: number, actionType?: "" | "DeletePost" | "RemoveMember" | "AcceptJoinRequest" | "DeclineJoinRequest" | "PostStatus" | "ChangeRank" | "BuyAd" | "SendAllyRequest" | "CreateEnemy" | "AcceptAllyRequest" | "DeclineAllyRequest" | "DeleteAlly" | "DeleteEnemy" | "AddGroupPlace" | "RemoveGroupPlace" | "CreateItems" | "ConfigureItems" | "SpendGroupFunds" | "ChangeOwner" | "Delete" | "AdjustCurrencyAmounts" | "Abandon" | "Claim" | "Rename" | "ChangeDescription" | "InviteToClan" | "KickFromClan" | "CancelClanInvite" | "BuyClan" | "CreateGroupAsset" | "UpdateGroupAsset" | "ConfigureGroupAsset" | "RevertGroupAsset" | "CreateGroupDeveloperProduct" | "ConfigureGroupGame" | "Lock" | "Unlock" | "CreateGamePass" | "CreateBadge" | "ConfigureBadge" | "SavePlace" | "PublishPlace", userId?: number, sortOrder?: SortOrder, limit?: Limit, cursor?: string, jar?: CookieJar ): Promise<AuditPage>;
+
+    /**
+     * 🔐 Get the social link data associated with a group.
+     */
+    function getGroupSocialLinks(groupId: number, jar?: CookieJar): Promise<SocialLinkResponse[]>;
 
     /**
      * 🔐 Gets the transaction history of the specified group.
@@ -1558,6 +1582,11 @@ declare module "noblox.js" {
      * ✅ Get the groups a user is in.
      */
     function getGroups(userId: number): Promise<Group[]>;
+
+    /**
+     * 🔐 Get the social link data (promotion channels) associated with a user.
+     */
+    function getUserSocialLinks(userId: number, jar?: CookieJar): Promise<PromotionChannelsResponse>;
 
     /**
      * 🔐 Gets the transaction history of the logged in user or of the user specified by the jar.
@@ -1946,7 +1975,7 @@ declare module "noblox.js" {
     /// Group
 
     /**
-     * This function emits all join requests and waits until all of them have been resolved by firing the `handle` event with the request and either true or false. You can also pass a third argument `callback` to handle to execute once the join request has been handled. Once all requests on a page have been resolved, the next page is collected. Make sure that all join requests are handled in some way. Because this function has to wait for input, it does handle timeouts but does them within the function as opposed to within shortPoll.
+     * 🔐 This function emits all join requests and waits until all of them have been resolved by firing the `handle` event with the request and either true or false. You can also pass a third argument `callback` to handle to execute once the join request has been handled. Once all requests on a page have been resolved, the next page is collected. Make sure that all join requests are handled in some way. Because this function has to wait for input, it does handle timeouts but does them within the function as opposed to within shortPoll.
      *
      * To accept all new users that aren't on a blacklist and send them a message, for example:
      * ```javascript
@@ -1970,14 +1999,14 @@ declare module "noblox.js" {
     function onJoinRequestHandle(group: number, jar?: CookieJar): OnJoinRequestHandleEventEmitter;
 
     /**
-     * Fires when there is a shout in the group with groupId `group`. If the shout was cleared the shout body will be blank.
+     * 🔓 Fires when there is a shout in the group with groupId `group`. If the shout was cleared the shout body will be blank.
      */
     function onShout(group: number, jar?: CookieJar): OnShoutEventEmitter;
 
     function onAuditLog(group: number, jar?: CookieJar): OnAuditLogEventEmitter;
 
     /**
-     * Fires when there is a new wall post in the group with groupId `group`. If `view` is enabled the wall posts viewstate will be returned in `view`, otherwise it will not be present.
+     * 🔓 Fires when there is a new wall post in the group with groupId `group`. If `view` is enabled the wall posts viewstate will be returned in `view`, otherwise it will not be present.
      */
     function onWallPost(group: number, view?: boolean, jar?: CookieJar): OnWallPostEventEmitter;
 
@@ -2005,17 +2034,17 @@ declare module "noblox.js" {
     /// User
 
     /**
-     * Fires when new friend requests are received.
+     * 🔐 Fires when new friend requests are received.
      */
     function onFriendRequest(jar?: CookieJar): OnFriendRequestEventEmitter;
 
     /**
-     * Fires whenever a new message is received. Because it relies on `onNotification`, the logged in user's notification stream for messages must be enabled; however, it is one of the true events and does not rely on short polling.
+     * 🔐 Fires whenever a new message is received. Because it relies on `onNotification`, the logged in user's notification stream for messages must be enabled; however, it is one of the true events and does not rely on short polling.
      */
     function onMessage(jar?: CookieJar): OnMessageEventEmitter;
 
     /**
-     * This is one of the only true streams, using web sockets to connect to ROBLOX's notification system. The logged in user must have relevant notifications enabled in their settings in order to receive notifications through this (of course). All notifications haven't been mapped out but what is known is that they all have a `name` and `message` (separate arguments to the `data` event), where `message` is an object that includes a field `type`.
+     * 🔐 This is one of the only true streams, using web sockets to connect to ROBLOX's notification system. The logged in user must have relevant notifications enabled in their settings in order to receive notifications through this (of course). All notifications haven't been mapped out but what is known is that they all have a `name` and `message` (separate arguments to the `data` event), where `message` is an object that includes a field `type`.
      */
     function onNotification(jar?: CookieJar): OnNotificationEventEmitter;
 
@@ -2033,7 +2062,7 @@ declare module "noblox.js" {
     function getAwardedTimestamps(userId: number, badgeId: number[]): Promise<UserBadgeStats>
 
     /**
-     * Updates badge information.
+     * 🔐 Updates badge information.
      */
     function updateBadgeInfo(badgeId: number, name?: string, description?: string, enabled?: boolean, jar?: CookieJar): Promise<void>
 }

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -620,6 +620,16 @@ type DeveloperProduct = {
 /**
  * @typedef
  */
+type SocialLinkResponse = {
+    id: number;
+    type: 'Facebook' | 'Twitter' | 'YouTube' | 'Twitch' | 'GooglePlus' | 'Discord' | 'RobloxGroup' | 'Amazon';
+    url: string;
+    title: string;
+}
+
+/**
+ * @typedef
+ */
 type DeveloperProductsResult = {
     DeveloperProducts: Array<DeveloperProduct>,
     FinalPage: boolean,
@@ -1192,10 +1202,20 @@ type Presences = {
 /**
  * @typedef
 */
-type playerThumbnailData = {
+type PlayerThumbnailData = {
     targetId: number;
     state: string;
     imageUrl: string;
+}
+
+/**
+ * @typedef
+ */
+type PromotionChannelsResponse = {
+    facebook?: string;
+    twitter?: string;
+    youtube?: string;
+    twitch?: string;
 }
 
 /// Badges


### PR DESCRIPTION
Closes issue #359.

Implements `getUserSocialLinks()`, `getGameSocialLinks()`, and `getGroupSocialLinks()`, with Jest test cases. I opted against the issue's requested name, `getUserPromotionChannels()` so it has parity with the naming scheme used on the website and companion methods.

![image](https://user-images.githubusercontent.com/34300238/122624172-fc210580-d06c-11eb-98da-b762d2686605.png)

**Test Cases using noblox.js group/account:**

![image](https://user-images.githubusercontent.com/34300238/122624058-8c127f80-d06c-11eb-86b5-c562f49f0aaf.png)
![image](https://user-images.githubusercontent.com/34300238/122624059-8f0d7000-d06c-11eb-896a-78a30a573f61.png)
![image](https://user-images.githubusercontent.com/34300238/122624074-9cc2f580-d06c-11eb-940e-aa6ed5c5dddd.png)
