### PR TITLE
Implement resale endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ At the end of the day, a 'bot' is a user account, it cannot magically bypass pri
 * [suufi](https://github.com/suufi) - Lead maintainer
 * [sentanos](https://github.com/sentanos) - We wouldn't exist without him. 😀
 * [Neztore](https://github.com/Neztore) - Library maintenance and review 
-* [Alan Bixby](https://github.com/alanbixby) - Library maintenance
+* [alanbixby](https://github.com/alanbixby) - Library maintenance
 * [popeeyy](https://github.com/popeeyy) - Creation of the documentation.
 * [edward](https://github.com/edwrddd) - Helping with the creation of the documentation.
 

--- a/lib/asset/getResaleData.js
+++ b/lib/asset/getResaleData.js
@@ -1,0 +1,54 @@
+// Includes
+const http = require('../util/http').func
+
+// Args
+exports.required = ['assetId']
+exports.optional = ['jar']
+
+// Docs
+/**
+ * ✅ Get the recent sale history (price and volume per day for 180 days) of a limited asset.
+ * @category Assets
+ * @alias getResaleData
+ * @param {number} assetId - The id of the asset.
+ * @returns {Promise<ResaleDataResponse>}
+ * @example const noblox = require("noblox.js")
+ * const resaleData = await noblox.getResaleData(20573078)
+**/
+
+// Define
+const getResaleData = async (assetId) => {
+  return http({
+    url: `//economy.roblox.com/v1/assets/${assetId}/resale-data`,
+    options: {
+      resolveWithFullResponse: true
+    }
+  }).then(({ body, statusCode }) => {
+    const { errors } = JSON.parse(body)
+    if (statusCode === 200) {
+      try {
+        const resaleData = JSON.parse(body)
+        for (const priceDataPoint of resaleData.priceDataPoints) {
+          priceDataPoint.date = new Date(priceDataPoint.date)
+        }
+        for (const volumeDataPoint of resaleData.volumeDataPoints) {
+          volumeDataPoint.date = new Date(volumeDataPoint.date)
+        }
+        return resaleData
+      } catch (err) {
+        throw new Error(`An unknown error occurred with getResaleData() | [${statusCode}] assetId: ${assetId}`)
+      }
+    } else if (statusCode === 400) {
+      throw new Error(`${errors[0].message} | assetId: ${assetId}`)
+    } else {
+      throw new Error(`An unknown error occurred with getResaleData() | [${statusCode}] assetId: ${assetId}`)
+    }
+  })
+}
+
+exports.func = function ({ assetId }) {
+  if (isNaN(assetId)) {
+    throw new Error('The provided assetId is not a number.')
+  }
+  return getResaleData(assetId)
+}

--- a/lib/asset/getResellers.js
+++ b/lib/asset/getResellers.js
@@ -1,0 +1,33 @@
+// Includes
+const getPageResults = require('../util/getPageResults.js').func
+
+// Args
+exports.required = ['assetId']
+exports.optional = ['limit', 'cursor']
+
+// Docs
+/**
+ * 🔐 Gets available resale copies of a limited asset.
+ * @category Assets
+ * @alias getResellers
+ * @param {number} assetId - The id of the asset.
+ * @param {Limit=} limit - The max number of resellers to return.
+ * @returns {Promise<ResellerData[]>}
+ * @example const noblox = require("noblox.js")
+ * const resellers = await noblox.getResellers(20573078)
+**/
+
+// Define
+const getResellers = async (assetId, limit, jar) => {
+  return getPageResults({
+    url: `//economy.roblox.com/v1/assets/${assetId}/resellers`,
+    limit: limit
+  })
+}
+
+exports.func = function ({ assetId, limit, jar }) {
+  if (isNaN(assetId)) {
+    throw new Error('The provided assetId ID is not a number.')
+  }
+  return getResellers(assetId, limit, jar)
+}

--- a/test/asset.test.js
+++ b/test/asset.test.js
@@ -1,4 +1,4 @@
-const { buy, configureItem, deleteFromInventory, getProductInfo, uploadItem, setCookie } = require('../lib')
+const { buy, configureItem, deleteFromInventory, getProductInfo, getResaleData, getResellers, uploadItem, setCookie } = require('../lib')
 const fs = require('fs')
 
 beforeAll(() => {
@@ -103,6 +103,43 @@ describe('Asset Methods', () => {
         Creator: expect.any(Object),
         PriceInRobux: expect.nullOrAny(Number)
       })
+    })
+  })
+
+  it('getResaleData() successfully returns a collectible\'s resale history', () => {
+    return getResaleData(20573078).then((res) => { // Shaggy
+      return expect(res).toMatchObject({
+        assetStock: expect.nullOrAny(Number),
+        sales: expect.any(Number),
+        numberRemaining: expect.nullOrAny(Number),
+        recentAveragePrice: expect.any(Number),
+        originalPrice: expect.nullOrAny(Number),
+        priceDataPoints: expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.nullOrAny(Number),
+            date: expect.nullOrAny(Date)
+          })
+        ])
+      })
+    })
+  })
+
+  it('getResellers() successfully returns a collectible\'s resellable copies', () => {
+    return getResellers(20573078).then((res) => { // Shaggy
+      return expect(res).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            userAssetId: expect.any(Number),
+            price: expect.any(Number),
+            serialNumber: expect.nullOrAny(Number),
+            seller: expect.objectContaining({
+              id: expect.any(Number),
+              type: expect.any(String),
+              name: expect.any(String)
+            })
+          })
+        ])
+      )
     })
   })
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -218,6 +218,34 @@ declare module "noblox.js" {
         price: number;
     }
 
+    interface ChartDataPointResponse {
+        value?: number;
+        date?: Date;
+    }
+
+    interface ResaleDataResponse {
+        assetStock?: number;
+        sales?: number;
+        numberRemaining?: number;
+        recentAveragePrice?: number;
+        originalPrice?: number;
+        priceDataPoints?: ChartDataPointResponse[];
+        volumeDataPoints?: ChartDataPointResponse[];
+    }
+
+    interface ResellerAgent {
+        id: number;
+        type: "User" | "Group";
+        name: string;
+    }
+
+    interface ResellerData {
+        userAssetId: number;
+        seller: ResellerAgent;
+        price: number;
+        serialNumber?: number;
+    }
+
     interface UploadItemResponse {
         id: number;
     }
@@ -1300,6 +1328,17 @@ declare module "noblox.js" {
      * 🔐 Deletes an item from the logged in user's inventory
      */
     function deleteFromInventory(assetId: number, jar?: CookieJar): Promise<void>;
+
+
+    /**
+     * ✅ Get the recent sale history (price and volume per day for 180 days) of a limited asset.
+     */
+    function getResaleData(assetId: number): Promise<ResaleDataResponse>;
+
+    /**
+     * 🔐 Gets available resale copies of a limited asset.
+     */
+    function getResellers(assetId: number, limit?: Limit, jar?: CookieJar): Promise<ResellerData[]>;
 
     /**
      * 🔐 Uploads an image stored in `file` as an `assetType` with `name`. If `groupId` is specified it will be uploaded to that group. This is for uploading shirts, pants, or decals which have the assetTypes `11`, `12`, and `13`, respectively. Returns the asset `id` of the new item.

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -208,6 +208,46 @@ type BuyAssetResponse = {
 /**
  * @typedef
 */
+type ChartDataPointResponse = {
+    value?: number;
+    date?: Date;
+}
+
+/**
+ * @typedef
+*/
+type ResaleDataResponse = {
+    assetStock?: number;
+    sales?: number;
+    numberRemaining?: number;
+    recentAveragePrice?: number;
+    originalPrice?: number;
+    priceDataPoints?: ChartDataPointResponse[];
+    volumeDataPoints?: ChartDataPointResponse[];
+}
+
+/**
+ * @typedef
+*/
+type ResellerAgent = {
+    id: number;
+    type: "User" | "Group";
+    name: string;
+}
+
+/**
+ * @typedef
+*/
+type ResellerData = {
+    userAssetId: number;
+    seller: ResellerAgent;
+    price: number;
+    serialNumber?: number;
+}
+
+/**
+ * @typedef
+*/
 type UploadItemResponse = {
     id: number;
 }


### PR DESCRIPTION
Closes issue #298.

Adds `getResaleData()` and `getResellers()` with unit tests.

**Unit Tests:**
![image](https://user-images.githubusercontent.com/34300238/122628807-64c8ac00-d086-11eb-9348-78682a9110ee.png)

---

**getResaleData():**
![image](https://user-images.githubusercontent.com/34300238/122628861-ca1c9d00-d086-11eb-8913-7b6c95182bd9.png)

**getResellers():**
![image](https://user-images.githubusercontent.com/34300238/122628850-b6713680-d086-11eb-8ca7-e3773d9bc52e.png)