### PR TITLE
Add displayNames support to getPlayerInfo()

### DIFF
--- a/lib/user/getPlayerInfo.js
+++ b/lib/user/getPlayerInfo.js
@@ -42,12 +42,14 @@ function getPlayerInfo (userId) {
         const blurb = userBody.description
         const isBanned = userBody.isBanned
         const username = userBody.name
+        const displayName = userBody.displayName
 
         resolve({
           username: username,
           joinDate: joinDate,
           blurb: blurb,
-          isBanned: isBanned
+          isBanned: isBanned,
+          displayName: displayName
         })
       } else if (failedResponse) {
         reject(new Error('User does not exist.'))
@@ -62,12 +64,14 @@ function getPlayerInfo (userId) {
         const blurb = userBody.description
         const isBanned = userBody.isBanned
         const username = userBody.name
+        const displayName = userBody.displayName
 
         const currentTime = new Date()
         const age = Math.round(Math.abs((joinDate.getTime() - currentTime.getTime()) / (24 * 60 * 60 * 1000)))
 
         resolve({
           username,
+          displayName,
           status,
           blurb,
           joinDate,


### PR DESCRIPTION
The commit https://github.com/noblox/noblox.js/commit/31de328d70e970d2a9f8f30c41b62d2027ecad50 added `displayName` to the typing of `PlayerInfo` but never added the functionality. This fixes that.

![image](https://user-images.githubusercontent.com/34300238/123561412-29a93580-d776-11eb-88b1-a2bfd75d4a52.png)
