### PR TITLE
Simplify jar overloading by permitting string inputs

### DIFF
--- a/lib/util/getCurrentUser.js
+++ b/lib/util/getCurrentUser.js
@@ -35,7 +35,13 @@ exports.func = function (args) {
         throw new Error('You are not logged in.')
       } else {
         const json = JSON.parse(res.body)
-        return (option ? json[option] : json)
+        if (option) {
+          const searchKey = Object.keys(json).filter((key) => {
+            return option.toLowerCase() === key.toLowerCase()
+          })[0]
+          return json[searchKey]
+        }
+        return json
       }
     })
 }

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -65,6 +65,9 @@ function http (url, opt) {
 
 exports.func = function (args) {
   const opt = args.options || {}
+  if (typeof opt.jar === 'string') {
+    opt.jar = { session: opt.jar }
+  }
   const jar = opt.jar
   let depth = args.depth || 0
   const full = opt.resolveWithFullResponse || false


### PR DESCRIPTION
To overload `jar`, you need to pass an object `{ session: 'COOKIE' }`, this is not intuitive and results in over complicated looking code.

```js
await noblox.getCurrentUser({ jar: { session: 'COOKIE' } })
// is now equivalent to
await noblox.getCurrentUser({ jar: 'COOKIE' })
```

This pull request removes the need for the session object, enabling a cookie string to be passed instead of the wrapper object- **backwards compatibility is maintained.**

---

`string` and `object (str)` highlight the new functionality

![image](https://user-images.githubusercontent.com/34300238/123895022-2a37fc80-d92d-11eb-8741-09e761863267.png)
![image](https://user-images.githubusercontent.com/34300238/123892857-594c6f00-d929-11eb-936c-54bb560b002e.png)

