### PR TITLE
Fix getAwardedTimestamps typings, jest case, allow number badgeId- breaking change

### DIFF
--- a/lib/badges/getAwardedTimestamps.js
+++ b/lib/badges/getAwardedTimestamps.js
@@ -2,7 +2,7 @@
 const http = require('../util/http').func
 
 // Args
-exports.required = ['userId', 'badgeId']
+exports.required = ['userId', 'badgeIds']
 
 // Docs
 /**
@@ -10,17 +10,17 @@ exports.required = ['userId', 'badgeId']
  * @category Badges
  * @alias getAwardedTimestamps
  * @param {number} userId - The userId of the user.
- * @param {Array<number>} badgeId - The ids of the badges.
- * @returns {Promise<UserBadgeStats>}
+ * @param {number|Array<number>} badgeIds - The id or ids of badges (up to 100).
+ * @returns {Promise<UserBadgeStats[]>}
  * @example const noblox = require("noblox.js")
  * const badges = await noblox.getAwardedTimestamps(1, [1, 2, 3])
 **/
 
 // Define
-const getAwardedTimestamps = (userId, badgeId) => {
+const getAwardedTimestamps = (userId, badgeIds) => {
   return new Promise((resolve, reject) => {
     const httpOpt = {
-      url: `https://badges.roblox.com/v1/users/${userId}/badges/awarded-dates?badgeIds=${badgeId.join(',')}`,
+      url: `https://badges.roblox.com/v1/users/${userId}/badges/awarded-dates?badgeIds=${badgeIds.join(',')}`,
       options: {
         method: 'GET',
         resolveWithFullResponse: true
@@ -37,16 +37,31 @@ const getAwardedTimestamps = (userId, badgeId) => {
           }
           reject(new Error(error))
         } else {
-          resolve(responseData)
+          resolve(responseData.data.map(obj => {
+            obj.awardedDate = new Date(obj.awardedDate)
+            return obj
+          }))
         }
       })
   })
 }
 
-exports.func = async (args) => {
-  if (isNaN(args.userId)) {
-    throw new Error('The provided User ID is not a number.')
+exports.func = async ({ userId, badgeIds }) => {
+  if (isNaN(userId)) {
+    throw new Error('The provided userId is not a number.')
   }
 
-  return getAwardedTimestamps(args.userId, args.badgeId)
+  if (typeof badgeIds === 'number') {
+    badgeIds = [badgeIds]
+  }
+
+  if (!Array.isArray(badgeIds) || badgeIds.some(isNaN)) {
+    throw new Error('The provided badgeIds were not a number or array of numbers.')
+  }
+
+  if (badgeIds.length > 100) {
+    throw new Error('Too many badgeIds were provided (max 100)')
+  }
+
+  return getAwardedTimestamps(userId, badgeIds)
 }

--- a/test/badges.test.js
+++ b/test/badges.test.js
@@ -11,9 +11,12 @@ beforeAll(() => {
 describe('Badges Methods', () => {
   it('getAwardedTimestamps() returns when badges were awarded to a player', () => {
     return getAwardedTimestamps(64679301, [459405541]).then((res) => {
-      return expect(res).toMatchObject({
-        data: expect.any(Array)
-      })
+      expect(res).toEqual(
+        expect.arrayContaining([{
+          badgeId: expect.any(Number),
+          awardedDate: expect.any(Date)
+        }])
+      )
     })
   })
 

--- a/test/badges.test.js
+++ b/test/badges.test.js
@@ -9,8 +9,19 @@ beforeAll(() => {
 })
 
 describe('Badges Methods', () => {
-  it('getAwardedTimestamps() returns when badges were awarded to a player', () => {
-    return getAwardedTimestamps(64679301, [459405541]).then((res) => {
+  it('getAwardedTimestamps() [NUMBER] returns when badges were awarded to a player', () => {
+    return getAwardedTimestamps(2416399685, 2124549302).then((res) => {
+      expect(res).toEqual(
+        expect.arrayContaining([{
+          badgeId: expect.any(Number),
+          awardedDate: expect.any(Date)
+        }])
+      )
+    })
+  })
+
+  it('getAwardedTimestamps() [ARRAY] returns when badges were awarded to a player', () => {
+    return getAwardedTimestamps(2416399685, [2124549302, 2124549305, 2124549306]).then((res) => {
       expect(res).toEqual(
         expect.arrayContaining([{
           badgeId: expect.any(Number),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2237,9 +2237,9 @@ declare module "noblox.js" {
     function getBadgeInfo(badgeId: number): Promise<BadgeInfo>
 
     /**
-     * ✅ Gets user award date for a badge.
+     * ✅ Gets the user awarded date for a badge or array of badges.
      */
-    function getAwardedTimestamps(userId: number, badgeId: number[]): Promise<UserBadgeStats>
+    function getAwardedTimestamps(userId: number, badgeIds: number[]): Promise<UserBadgeStats[]>
 
     /**
      * 🔐 Updates badge information.


### PR DESCRIPTION
This pull request was intended to make `badgeId` accept a `number` **or** `Array<number>` instead of just `Array<number>`, however I stumbled into several blatant errors that were also fixed.

```js
// New Functionality
await noblox.getAwardedTimestamps(2416399685, [2124549302])
// is now equivalent to
await noblox.getAwardedTimestamps(2416399685, 2124549302)
```

In it's previous state `getAwardedTimestamps` needlessly returns a data object with no cursors, this is not reflected in [`UserBadgeStats`](https://noblox.js.org/global.html#UserBadgeStats), likewise, `awardedDate` is currently a `string`, not a `Date`:
```js
// Old Return
{
    data: [ { badgeId: 19450168, awardedDate: '2010-01-09T20:54:57.38Z' } ]
}
// New Return
[ { badgeId: 19450168, awardedDate: 2010-01-09T20:54:57.38Z } ]
```

I have fixed these errors, updated the return type, and made the jest case more precise to reflect these changes.

![image](https://user-images.githubusercontent.com/34300238/124398286-f53bf900-dce2-11eb-9d9f-2d0579399f1e.png)

---

This pull request introduces two breaking changes:
- The return is no longer encapsulated by a `data` object - QoL improvement which agrees with the type interface, but introduces a breaking change
- `awardedDate` is now a `Date` instead of a `string` - this is what the original typings intended
- The parameter `badgeId` is renamed to `badgeIds` - breaks object parameter (included since return already would be breaking)