### PR TITLE
Fix getPlayerInfo() - remove status

### DIFF
--- a/lib/user/getPlayerInfo.js
+++ b/lib/user/getPlayerInfo.js
@@ -21,7 +21,6 @@ function getPlayerInfo (userId) {
   return new Promise((resolve, reject) => {
     const requests = [
       constructRequest(`//users.roblox.com/v1/users/${userId}`),
-      constructRequest(`//users.roblox.com/v1/users/${userId}/status`),
       constructRequest(`//friends.roblox.com/v1/users/${userId}/friends/count`),
       constructRequest(`//friends.roblox.com/v1/users/${userId}/followings/count`),
       constructRequest(`//friends.roblox.com/v1/users/${userId}/followers/count`),
@@ -52,14 +51,14 @@ function getPlayerInfo (userId) {
           displayName: displayName
         })
       } else if (failedResponse) {
+        console.log(failedResponse)
         reject(new Error('User does not exist.'))
       } else {
         const responseBodies = responses.map(res => res.body)
-        const status = responseBodies[1].status
-        const oldNames = responses[5].map(nameObject => nameObject.name) || []
-        const friendCount = responseBodies[2].count
-        const followerCount = responseBodies[4].count
-        const followingCount = responseBodies[3].count
+        const oldNames = responses[4].map(nameObject => nameObject.name) || []
+        const friendCount = responseBodies[1].count
+        const followerCount = responseBodies[3].count
+        const followingCount = responseBodies[2].count
         const joinDate = new Date(userBody.created)
         const blurb = userBody.description
         const isBanned = userBody.isBanned
@@ -72,7 +71,6 @@ function getPlayerInfo (userId) {
         resolve({
           username,
           displayName,
-          status,
           blurb,
           joinDate,
           age,

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -303,7 +303,6 @@ describe('User Methods', () => {
     return getPlayerInfo(55549140).then((res) => {
       return expect(res).toMatchObject({
         username: expect.any(String),
-        status: expect.any(String),
         blurb: expect.any(String),
         joinDate: expect.any(Date),
         age: expect.any(Number),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1088,7 +1088,6 @@ declare module "noblox.js" {
     interface PlayerInfo {
         username: string;
         displayName: string;
-        status?: string;
         blurb: string;
         joinDate: Date;
         age?: number;

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -1351,7 +1351,6 @@ type UserPresence = {
 type PlayerInfo = {
     username: string;
     displayName: string;
-    status?: string;
     blurb: string;
     joinDate: Date;
     age?: number;


### PR DESCRIPTION
This pull request removes `status` from the return type of `getPlayerInfo()` which was already nearing deprecation status. This may not be favorable as it introduces a breaking change for those reliant on status in `getPlayerInfo()`.

See #384 for an alternative.

---

**Context:** As of July 9th, 2021, the endpoint `https://users.roblox.com/v1/users/<USERID>/status` developed a rate limit around 1 request per minute- which can be considered unusable for most applications.
