### PR TITLE
Fix getPlayerInfo() - use www endpoint

### DIFF
--- a/lib/user/getPlayerInfo.js
+++ b/lib/user/getPlayerInfo.js
@@ -1,6 +1,5 @@
 // Includes
 const http = require('../util/http.js').func
-const getPageResults = require('../util/getPageResults.js').func
 
 // Args
 exports.required = ['userId']
@@ -21,11 +20,7 @@ function getPlayerInfo (userId) {
   return new Promise((resolve, reject) => {
     const requests = [
       constructRequest(`//users.roblox.com/v1/users/${userId}`),
-      constructRequest(`//users.roblox.com/v1/users/${userId}/status`),
-      constructRequest(`//friends.roblox.com/v1/users/${userId}/friends/count`),
-      constructRequest(`//friends.roblox.com/v1/users/${userId}/followings/count`),
-      constructRequest(`//friends.roblox.com/v1/users/${userId}/followers/count`),
-      getPageResults({ url: `//users.roblox.com/v1/users/${userId}/username-history`, query: {}, limit: 1000 })
+      constructRequest(`//www.roblox.com/users/profile/profileheader-json?userid=${userId}`)
     ].map(promise => promise.then(
       val => ({ status: 'fulfilled', value: val }),
       rej => ({ status: 'rejected', reason: rej })
@@ -54,18 +49,19 @@ function getPlayerInfo (userId) {
       } else if (failedResponse) {
         reject(new Error('User does not exist.'))
       } else {
-        const responseBodies = responses.map(res => res.body)
-        const status = responseBodies[1].status
-        const oldNames = responses[5].map(nameObject => nameObject.name) || []
-        const friendCount = responseBodies[2].count
-        const followerCount = responseBodies[4].count
-        const followingCount = responseBodies[3].count
         const joinDate = new Date(userBody.created)
         const blurb = userBody.description
         const isBanned = userBody.isBanned
         const username = userBody.name
         const displayName = userBody.displayName
-
+        const {
+          UserStatus: status,
+          FriendsCount: friendCount,
+          FollowersCount: followerCount,
+          FollowingsCount: followingCount,
+          PreviousUserNames: oldNamesString
+        } = responses[1].body
+        const oldNames = oldNamesString.split('\r\n') || []
         const currentTime = new Date()
         const age = Math.round(Math.abs((joinDate.getTime() - currentTime.getTime()) / (24 * 60 * 60 * 1000)))
 


### PR DESCRIPTION
This pull request bypasses the rate limit issues by transitioning from the `users.` endpoint to a `www.`; this not favorable as Roblox does not warn of changes on these endpoints, however this pull request does not introduce any breaking changes.

Since the `www.` endpoint is being implemented, this simplifies the method quite a bit, removing four redundant web requests.

See #383  for an alternative.
 
---

**Context:** As of July 9th, 2021, the endpoint `https://users.roblox.com/v1/users/<USERID>/status` developed a rate limit around 1 request per minute- which can be considered unusable for most applications.
