### PR TITLE
Implement updateUniverseAccess()

### DIFF
--- a/lib/game/updateUniverseAccess.js
+++ b/lib/game/updateUniverseAccess.js
@@ -1,0 +1,55 @@
+// Includes
+const http = require('../util/http.js').func
+const getGeneralToken = require('../util/getGeneralToken.js').func
+
+// Args
+exports.required = ['universeId', 'isPublic']
+exports.optional = ['jar']
+
+// Docs
+/**
+ * 🔐 Modifies a universe's public access setting
+ * @category Game
+ * @alias updateUniverseAccess
+ * @param {number} universeId - The universeId of the experience
+ * @param {boolean=} isPublic - The visibility and access of the universe; shuts down all running instances if set to false
+ * @returns {Promise<void>}
+ * @example const noblox = require("noblox.js")
+ * // Login using your cookie
+ * noblox.updateUniverseAccess(2421261122, true)
+**/
+
+// Define
+function updateUniverseAccess (universeId, isPublic, jar, token) {
+  return new Promise((resolve, reject) => {
+    return http({
+      url: `//develop.roblox.com/v1/universes/${universeId}/${isPublic ? 'activate' : 'deactivate'}`,
+      options: {
+        method: 'POST',
+        jar,
+        headers: {
+          'X-CSRF-TOKEN': token
+        },
+        json: {
+          universeId
+        },
+        resolveWithFullResponse: true
+      }
+    }).then(({ statusCode, body }) => {
+      if (statusCode === 200) {
+        resolve()
+      } else if (body && body.errors) {
+        reject(new Error(`[${statusCode}] ${body.errors[0].message} | universeId: ${universeId}, isPublic: ${isPublic} ${body.errors.field ? ` | ${body.errors.field} is incorrect` : ''}`))
+      } else {
+        reject(new Error(`An unknown error occurred with updateUniverseAccess() | [${statusCode}] universeId: ${universeId}, isPublic: ${isPublic}`))
+      }
+    })
+  })
+}
+
+exports.func = function ({ universeId, isPublic, jar }) {
+  return getGeneralToken({ jar })
+    .then((token) => {
+      return updateUniverseAccess(universeId, isPublic, jar, token)
+    })
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1493,6 +1493,11 @@ declare module "noblox.js" {
      */
     function getGameSocialLinks(universeId: number, jar?: CookieJar): Promise<SocialLinkResponse[]>;
 
+    /**
+     * 🔐 Updates a universe's public access setting
+    */
+   function updateUniverseAccess (universeId, isPublic, jar, token): Promise<void>;
+
     /// Group
 
     /**


### PR DESCRIPTION
Sets the universe root place to private or public.

This was a requested method via the noblox.js support server; this method can be used by developers to automatically open and close their game for a beta weekend without needing to stay up late/wake up early to manually lock their game.

I have omitted test cases do to their reliance on internal cookies; likewise since the success state returns `{}`, an [additional method would needed](https://games.roblox.com/docs#!/Games/get_v1_games_multiget_playability_status) to be implemented to validate if the target universe changed it's access settings.