### PR TITLE
Implement updatePrivateServerPermissions

### DIFF
--- a/lib/game/updatePrivateServerPermissions.js
+++ b/lib/game/updatePrivateServerPermissions.js
@@ -1,0 +1,68 @@
+// Includes
+const http = require('../util/http').func
+const getGeneralToken = require('../util/getGeneralToken').func
+
+// Args
+exports.required = ['privateServerId', 'permissionOptions']
+exports.optional = ['jar']
+
+// Implementation Comment
+/**
+ * The permissionOptions, "clanAllowed" and "enemyClanId", are documented in the Roblox API,
+ * but currently serve no function, thus they have been omitted from noblox.js's documentation.
+ */
+
+// Docs
+/**
+ * 🔐 Update access settings to a private server (formerly VIP servers)
+ * @category Game
+ * @alias updatePrivateServerPermissions
+ * @param {number} privateServerId - the id of the private server instance
+ * @param {boolean} permissionOptions.friendsAllowed - allow all friends to join the private server
+ * @param {number | Array<number>} permissionOptions.usersToAdd - the userId or array of userId to add to the private server; subject to a target's privacy settings
+ * @param {number | Array<number>} permissionOptions.usersToRemove - the userId or array of userId to remove from the private server
+ * @returns {Promise<PrivateServerPermissionsResponse>}
+**/
+
+// Define
+const updatePrivateServerPermissions = async (privateServerId, permissionOptions, jar, token) => {
+  return http({
+    url: `//games.roblox.com/v1/vip-servers/${privateServerId}/permissions`,
+    options: {
+      method: 'PATCH',
+      jar,
+      headers: {
+        'X-CSRF-Token': token
+      },
+      json: permissionOptions,
+      resolveWithFullResponse: true
+    }
+  }).then(({ body, statusCode }) => {
+    const { errors } = body
+    if (statusCode === 200) {
+      return body
+    } else if (errors) {
+      throw new Error(`[${statusCode}] ${errors[0].message} | privateServerId: ${privateServerId}, permissionOptions: ${JSON.stringify(permissionOptions)}`)
+    } else {
+      throw new Error(`An unknown error occurred with getResaleData() | [${statusCode}] privateServerId: ${privateServerId}, permissionOptions: ${JSON.stringify(permissionOptions)}`)
+    }
+  })
+}
+
+exports.func = function ({ privateServerId, permissionOptions, jar }) {
+  if (typeof permissionOptions.usersToAdd === 'number') {
+    permissionOptions.usersToAdd = [permissionOptions.usersToAdd]
+  }
+
+  if (typeof permissionOptions.usersToRemove === 'number') {
+    permissionOptions.usersToRemove = [permissionOptions.usersToRemove]
+  }
+
+  if (!(typeof permissionOptions === 'object')) {
+    throw new TypeError('permissionOptions was not an object: https://noblox.js.org/global.html#updatePrivateServerPermissions')
+  }
+
+  return getGeneralToken({ jar: jar }).then((token) => {
+    return updatePrivateServerPermissions(privateServerId, permissionOptions, jar, token)
+  })
+}

--- a/lib/game/updatePrivateServerPermissions.js
+++ b/lib/game/updatePrivateServerPermissions.js
@@ -22,6 +22,9 @@ exports.optional = ['jar']
  * @param {number | Array<number>} permissionOptions.usersToAdd - the userId or array of userId to add to the private server; subject to a target's privacy settings
  * @param {number | Array<number>} permissionOptions.usersToRemove - the userId or array of userId to remove from the private server
  * @returns {Promise<PrivateServerPermissionsResponse>}
+ * @example const noblox = require("noblox.js")
+ * // Login using your cookie
+ * await noblox.updatePrivateServerPermissions(253181108, { friendsAllowed: true, usersToAdd: 2416399685, usersToRemove: [5903228, 55549140] })
 **/
 
 // Define

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -714,6 +714,21 @@ declare module "noblox.js" {
         Message: string;
     }
 
+    interface PermissionsOptions
+    {
+        friendsAllowed?: boolean;
+        usersToAdd?: number | Array<number>
+        usersToRemove?: number | Array<number>
+    }
+
+    interface PrivateServerPermissionsResponse
+    {
+        clanAllowed?: boolean;
+        enemyClanId?: number | null;
+        friendsAllowed: boolean;
+        users: Array<SkinnyUserResponse>
+    }
+
     /// Group
 
     type GroupIconSize = "150x150" | "420x420"
@@ -1327,6 +1342,11 @@ declare module "noblox.js" {
         repeat?: boolean;
     }
 
+    interface SkinnyUserResponse {
+        id: number;
+        name: string;
+        displayName: string;
+    }
 
     // Functions
 
@@ -1521,7 +1541,16 @@ declare module "noblox.js" {
     /**
      * 🔐 Updates a universe's public access setting
     */
-   function updateUniverseAccess (universeId, isPublic, jar, token): Promise<void>;
+    function updateUniverseAccess(universeId: number, isPublic: boolean, jar?: CookieJar): Promise<void>;
+
+    /**
+     * 🔐 Update access settings to a private server (formerly VIP servers)
+     * @param {number} privateServerId - the id of the private server instance
+     * @param {boolean} permissionOptions.friendsAllowed - allow all friends to join the private server
+     * @param {number | Array<number>} permissionOptions.usersToAdd - the userId or array of userId to add to the private server; subject to a target's privacy settings
+     * @param {number | Array<number>} permissionOptions.usersToRemove - the userId or array of userId to remove from the private server
+    */
+    function updatePrivateServerPermissions(universeId: number, permissionOptions: PermissionsOptions ): Promise<PrivateServerPermissionsResponse>;
 
     /// Group
 

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -840,6 +840,16 @@ type CheckDeveloperProductNameResult = {
     Message: string;
 }
 
+/**
+ * @typedef
+ */
+type PrivateServerPermissionsResponse = {
+    clanAllowed: boolean;
+    enemyClanId: number | null;
+    friendsAllowed: boolean;
+    users: Array<SkinnyUserResponse>
+}
+
 /// Group
 
 /**
@@ -1671,4 +1681,13 @@ type GetLatestResponse = {
     latest: number;
     data: object;
     repeat?: boolean;
+}
+
+/**
+ * @typedef
+ */
+type SkinnyUserResponse = {
+    id: number;
+    name: string;
+    displayName: string;
 }


### PR DESCRIPTION
Adding private server endpoints- this modifies the access settings of a private server. I've omitted `clanAllowed` and `enemyClanId` as they appear to either be legacy or not implemented yet.

Keeping this PR as a draft until the remaining endpoints are added, and test cases are written.