### PR TITLE
Implement getGamePasses and fix getResellers jar param

### DIFF
--- a/lib/asset/getResellers.js
+++ b/lib/asset/getResellers.js
@@ -3,7 +3,7 @@ const getPageResults = require('../util/getPageResults.js').func
 
 // Args
 exports.required = ['assetId']
-exports.optional = ['limit', 'cursor']
+exports.optional = ['limit', 'jar']
 
 // Docs
 /**
@@ -14,6 +14,7 @@ exports.optional = ['limit', 'cursor']
  * @param {Limit=} limit - The max number of resellers to return.
  * @returns {Promise<ResellerData[]>}
  * @example const noblox = require("noblox.js")
+ * // Login using your cokkie
  * const resellers = await noblox.getResellers(20573078)
 **/
 
@@ -21,7 +22,8 @@ exports.optional = ['limit', 'cursor']
 const getResellers = async (assetId, limit, jar) => {
   return getPageResults({
     url: `//economy.roblox.com/v1/assets/${assetId}/resellers`,
-    limit: limit
+    limit,
+    jar
   })
 }
 

--- a/lib/asset/getResellers.js
+++ b/lib/asset/getResellers.js
@@ -14,7 +14,7 @@ exports.optional = ['limit', 'jar']
  * @param {Limit=} limit - The max number of resellers to return.
  * @returns {Promise<ResellerData[]>}
  * @example const noblox = require("noblox.js")
- * // Login using your cokkie
+ * // Login using your cookie
  * const resellers = await noblox.getResellers(20573078)
 **/
 

--- a/lib/game/getGamePasses.js
+++ b/lib/game/getGamePasses.js
@@ -1,0 +1,39 @@
+// Includes
+const getPageResults = require('../util/getPageResults.js').func
+
+// Args
+exports.required = ['universeId']
+exports.optional = ['limit']
+
+// Docs
+/**
+ * ✅ Gets a game's game passes.
+ * @category Games
+ * @alias getGamePasses
+ * @param {number} universeId - The id of the universe.
+ * @param {Limit=} limit - The max number of game passes to return.
+ * @returns {Promise<GamePassData[]>}
+ * @example const noblox = require("noblox.js")
+ * const gamePasses = await noblox.getGamePasses(1686885941)
+**/
+
+// Define
+const getGamePasses = async (universeId, limit) => {
+  return getPageResults({
+    url: `//games.roblox.com/v1/games/${universeId}/game-passes`,
+    limit
+  }).catch(err => {
+    if (err.message === '404 The requested universe does not exist.') {
+      err.message += '\n\nYou are possibly providing a placeId instead of a universeId.\nUse getPlaceInfo() to retrieve the universeId: https://noblox.js.org/global.html#getPlaceInfo\n'
+      throw err
+    }
+    throw err
+  })
+}
+
+exports.func = function ({ universeId, limit }) {
+  if (isNaN(universeId)) {
+    throw new Error('The provided universe ID is not a number.')
+  }
+  return getGamePasses(universeId, limit)
+}

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -1,4 +1,4 @@
-const { addDeveloperProduct, checkDeveloperProductName, configureGamePass, getDeveloperProducts, getGameBadges, getGameInstances, getGameSocialLinks, getPlaceInfo, updateDeveloperProduct, setCookie } = require('../lib')
+const { addDeveloperProduct, checkDeveloperProductName, configureGamePass, getDeveloperProducts, getGameBadges, getGameInstances, getGamePasses, getGameSocialLinks, getPlaceInfo, updateDeveloperProduct, setCookie } = require('../lib')
 
 beforeAll(() => {
   return new Promise(resolve => {
@@ -78,6 +78,22 @@ describe('Game Methods', () => {
         Collection: expect.any(Array),
         TotalCollectionSize: expect.any(Number)
       })
+    })
+  })
+
+  it('getGamePasses() should return an array of game passes, given universeId', () => {
+    return getGamePasses(2615802125).then((res) => {
+      return expect(res).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            name: expect.any(String),
+            displayName: expect.any(String),
+            productId: expect.any(Number),
+            price: expect.any(Number)
+          })
+        ])
+      )
     })
   })
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -714,6 +714,15 @@ declare module "noblox.js" {
         Message: string;
     }
 
+    interface GamePassData
+    {
+        id: number;
+        name: string;
+        displayName: string;
+        productId?: number;
+        price?: number;
+    }
+
     /// Group
 
     type GroupIconSize = "150x150" | "420x420"
@@ -1474,8 +1483,16 @@ declare module "noblox.js" {
      * @param startIndex The index to start from in regards to server list.
      */
     function getGameInstances(placeId: number, startIndex: number): Promise<GameInstances>;
-
+    
+    /**
+     * ✅ Get the badges in a specific game.
+     */
     function getGameBadges(universeId: number, limit?: Limit, cursor?: string, sortOrder?: SortOrder): Promise<BadgeInfo>
+
+    /**
+     * ✅ Gets a game's game passes.
+     */
+    function getGamePasses(universeId: number, limit?: Limit): Promise<GamePassData[]>
 
     /**
      * 🔓 Returns information about the place in question, such as description, name etc; varies based on whether or not you're logged in.

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -840,6 +840,17 @@ type CheckDeveloperProductNameResult = {
     Message: string;
 }
 
+/**
+ * @typedef
+ */
+type GamePassData = {
+    id: number;
+    name: string;
+    displayName: string;
+    productId?: number;
+    price?: number;
+}
+
 /// Group
 
 /**


### PR DESCRIPTION
Adds `getGamePasses` and passes `jar` in `getResellers` for cookie overloading support.

![image](https://user-images.githubusercontent.com/34300238/130375495-0f74e38c-5c2b-4473-84f2-d7a9458ed384.png)
![image](https://user-images.githubusercontent.com/34300238/130375584-9187d087-17c3-4140-8fc6-4282b1566898.png)

Closes issue #400.