### PR TITLE
Bumped the getGroupTransactions url to v2

### DIFF
--- a/lib/group/getGroupTransactions.js
+++ b/lib/group/getGroupTransactions.js
@@ -1,8 +1,7 @@
-const http = require('../util/http.js').func
-const Promise = require('bluebird')
+const getPageResults = require('../util/getPageResults.js').func
 
 exports.required = ['group']
-exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
+exports.optional = ['transactionType', 'limit', 'sortOrder', 'jar']
 
 // Docs
 /**
@@ -10,46 +9,24 @@ exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
  * @category Group
  * @alias getGroupTransactions
  * @param {number} group - The id of the group.
- * @param {("Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout")} transactionType - The transaction type.
- * @param {Limit=} limit - The maximum results per a page.
- * @param {string=} cursor - The cursor for the next page.
- * @returns {Promise<TransactionPage>}
+ * @param {("Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout")} [transactionType=Sale] - The transaction type.
+ * @param {number} limit - The number of transactions being fetched in total.
+ * @param {SortOrder=} [sortOrder=Asc] - The cursor for the next page.
+ * @returns {Promise<TransactionItem[]>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * const transactions = await noblox.getGroupTransactions(1, "Sale")
 **/
 
-function getTransactions (group, transactionType, limit, cursor, jar) {
-  return new Promise((resolve, reject) => {
-    const httpOpt = {
-      url: `https://economy.roblox.com/v2/groups/${group}/transactions?cursor=${cursor}&limit=${limit}&sortOrder=Asc&transactionType=${transactionType}`,
-      options: {
-        method: 'GET',
-        resolveWithFullResponse: true,
-        jar: jar
-      }
-    }
-
-    return http(httpOpt)
-      .then(function (res) {
-        const responseData = JSON.parse(res.body)
-        if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
-        } else {
-          resolve(responseData)
-        }
-      })
-  })
-}
-
 // Define
 exports.func = function (args) {
-  const transactionType = args.transactionType || 'Sale'
-  const limit = args.limit || 100
-  const cursor = args.cursor || ''
-  return getTransactions(args.group, transactionType, limit, cursor)
+  return getPageResults({
+    jar: args.jar,
+    url: `//economy.roblox.com/v2/groups/${args.group}/transactions`,
+    query: {
+      transactionType: args.transactionType || 'Sale'
+    },
+    sortOrder: args.sortOrder || 'Asc',
+    limit: args.limit
+  })
 }

--- a/lib/group/getGroupTransactions.js
+++ b/lib/group/getGroupTransactions.js
@@ -22,7 +22,7 @@ exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
 function getTransactions (group, transactionType, limit, cursor, jar) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
-      url: `https://economy.roblox.com/v1/groups/${group}/transactions?limit=${limit}&transactionType=${transactionType}&cursor=${cursor}`,
+      url: `https://economy.roblox.com/v2/groups/${group}/transactions?cursor=${cursor}&limit=${limit}&sortOrder=Asc&transactionType=${transactionType}`,
       options: {
         method: 'GET',
         resolveWithFullResponse: true,

--- a/lib/user/getUserTransactions.js
+++ b/lib/user/getUserTransactions.js
@@ -1,8 +1,8 @@
-const http = require('../util/http.js').func
+const getPageResults = require('../util/getPageResults.js').func
 const getCurrentUser = require('../util/getCurrentUser.js').func
 
 exports.required = []
-exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
+exports.optional = ['transactionType', 'limit', 'sortOrder', 'jar']
 
 // Docs
 /**
@@ -10,47 +10,25 @@ exports.optional = ['transactionType', 'limit', 'cursor', 'jar']
  * @category User
  * @alias getUserTransactions
  * @param {("Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout")} [transactionType=Sale] - The type of transactions being fetched.
- * @param {Limit=} [limit=100] - The number of transactions being fetched each request. | [10, 25, 50, 100]
- * @param {string=} cursor - The previous or next page cursor.
- * @returns {Promise<TransactionPage>}
+ * @param {number} limit - The number of transactions being fetched in total.
+ * @param {SortOrder=} [sortOrder=Asc] - The cursor for the next page.
+ * @returns {Promise<TransactionItem[]>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * let transactions = await noblox.getUserTransactions("Sale", 10)
 **/
 
-function getTransactions (userId, transactionType, limit, cursor, jar) {
-  return new Promise((resolve, reject) => {
-    const httpOpt = {
-      url: `https://economy.roblox.com/v2/users/${userId}/transactions?limit=${limit}&transactionType=${transactionType}&cursor=${cursor}`,
-      options: {
-        method: 'GET',
-        resolveWithFullResponse: true,
-        jar: jar
-      }
-    }
-
-    return http(httpOpt)
-      .then(function (res) {
-        const responseData = JSON.parse(res.body)
-        if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
-        } else {
-          resolve(responseData)
-        }
-      })
-  })
-}
-
-// Define
 exports.func = async function (args) {
   const jar = args.jar
-  const transactionType = args.transactionType || 'Sale'
-  const limit = args.limit || 100
-  const cursor = args.cursor || ''
   const currentUser = await getCurrentUser({ jar: jar })
-  return getTransactions(currentUser.UserID, transactionType, limit, cursor)
+  // return getTransactions(currentUser.UserID, transactionType, limit, cursor)
+  return getPageResults({
+    jar: args.jar,
+    url: `//economy.roblox.com/v2/users/${currentUser.UserID}/transactions`,
+    query: {
+      transactionType: args.transactionType || 'Sale'
+    },
+    sortOrder: args.sortOrder || 'Asc',
+    limit: args.limit
+  })
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -902,19 +902,12 @@ declare module "noblox.js" {
     interface TransactionItem
     {
         id: number;
-        transactionType: string;
+        transactionType?: string;
         created: Date;
         isPending: boolean;
         agent: TransactionAgent;
         details?: TransactionDetails;
         currency: TransactionCurrency;
-    }
-
-    interface TransactionPage
-    {
-        data: TransactionItem[];
-        nextPageCursor?: string;
-        previousPageCursor?: string;
     }
 
     interface GroupJoinRequester
@@ -1625,7 +1618,7 @@ declare module "noblox.js" {
     /**
      * 🔐 Gets the transaction history of the specified group.
      */
-    function getGroupTransactions(group: number, transactionType?: "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
+    function getGroupTransactions(group: number, transactionType?: "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: number, sortOrder?: SortOrder, jar?: CookieJar): Promise<TransactionItem[]>;
 
     /**
      * ✅ Gets a brief overview of the specified group.
@@ -1820,7 +1813,7 @@ declare module "noblox.js" {
     /**
      * 🔐 Gets the transaction history of the logged in user or of the user specified by the jar.
      */
-    function getUserTransactions(transactionType?: "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: Limit, cursor?: string, jar?: CookieJar): Promise<TransactionPage>;
+    function getUserTransactions(transactionType?: "Sale" | "Purchase" | "AffiliateSale" | "DevEx" | "GroupPayout" | "AdImpressionPayout", limit?: number, sortOrder?: SortOrder, jar?: CookieJar): Promise<TransactionItem[]>;
 
 
     /**

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -1113,20 +1113,13 @@ type TransactionCurrency = {
  * @typedef
 */
 type TransactionItem = {
+    id: number;
+    transactionType?: string;
     created: Date;
     isPending: boolean;
     agent: TransactionAgent;
     details?: TransactionDetails;
     currency: TransactionCurrency;
-}
-
-/**
- * @typedef
-*/
-type TransactionPage = {
-    data: Array<TransactionItem>;
-    nextPageCursor?: string;
-    previousPageCursor?: string;
 }
 
 /**


### PR DESCRIPTION
Current getGroupTransactions is not working with the cursor parameter but bumping it up to v2 solves the issue. Roblox is now using this by default.

Everything remains the same except for the URL.