### PR TITLE
Fix onGroupTransaction and make getPageResults use bluebird

### DIFF
--- a/lib/group/onGroupTransaction.js
+++ b/lib/group/onGroupTransaction.js
@@ -11,6 +11,9 @@ exports.optional = ['jar']
  * 🔐 An event for when a group transaction is made, for example a purchase. This event has a rate of one request per 60
  * sec, which is more than the typical 10 seconds. This is due to the unusually low rate limit on the transactions
  * endpoint.
+ *
+ * Note: The `created` field returned by this event will always have 0 milliseconds. This is due to a quirk on Roblox's side:
+ * These millisecond values fluctuate, meaning the event can misfire. Removing them avoids this problem.
  * @category Group
  * @alias onGroupTransaction
  * @param {number} groupId - The id of the group.
@@ -34,17 +37,21 @@ exports.func = function (args) {
           // This method works much in the same way as onAuditLog. We remove some of the precision from transaction dates
           // Because Roblox has a habit of being imprecise and varying the milliseconds of a given transaction/log item
           // across different requests - and this causes duplicate fires.
-          if (transactions.data) {
-            for (const key in transactions.data) {
-              if (Object.prototype.hasOwnProperty.call(transactions.data, key)) {
-                const date = new Date(transactions.data[key].created.slice(0, transactions.data[key].created.lastIndexOf('.')))
+          if (transactions) {
+            for (const key in transactions) {
+              if (Object.prototype.hasOwnProperty.call(transactions, key)) {
+                const date = transactions[key].created
+                date.setMilliseconds(0)
+
                 if (date > latest) {
                   latest = date
-                  given.push(transactions.data[key])
+                  given.push(transactions[key])
                 }
                 empty = false
               } else if (!empty) {
                 const date = new Date()
+                date.setMilliseconds(0)
+
                 given.push({ date: date })
                 latest = date
                 empty = true

--- a/lib/util/getPageResults.js
+++ b/lib/util/getPageResults.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('./http.js').func
+const Promise = require('bluebird')
 
 // Args
 exports.required = ['url', 'query', 'limit']

--- a/lib/util/getPageResults.js
+++ b/lib/util/getPageResults.js
@@ -1,6 +1,5 @@
 // Includes
 const http = require('./http.js').func
-const Promise = require('bluebird')
 
 // Args
 exports.required = ['url', 'query', 'limit']


### PR DESCRIPTION
- getPageResults must use Bluebird to expose Promise.timeout: Used for all shortPoll events.
- Breaking changes were merged to getGroupTransactions without updating dependent methods. My bad! I approved it.

In future we should consider:
- Improving/working on shortPoll - it can be a bit flimsy
- Getting rid of Bluebird - we mostly use Promise.timeout and it's not really needed now - native promises are a lot better than they used to be. We could drop a dependency reasonably easily.