### PR TITLE
Fix documentation spelling (Colours -> Colors)

### DIFF
--- a/lib/avatar/setAvatarBodyColors.js
+++ b/lib/avatar/setAvatarBodyColors.js
@@ -18,7 +18,7 @@ exports.optional = ['jar']
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.setAvatarBodyColours(125, 125, 125, 125, 125, 125)
+ * noblox.setAvatarBodyColors(125, 125, 125, 125, 125, 125)
 **/
 
 const nextFunction = (jar, token, headColorId, torsoColorId, rightArmColorId, leftArmColorId, rightLegColorId, leftLegColorId) => {
@@ -46,7 +46,7 @@ const nextFunction = (jar, token, headColorId, torsoColorId, rightArmColorId, le
         throw new Error(res.body)
       }
     } else {
-      throw new Error('Set body colours failed')
+      throw new Error('Set body colors failed')
     }
   })
 }


### PR DESCRIPTION
Someone accidently put/forgot to remove "Colours"

Resolves #506 