### PR TITLE
fix: set optional authentication in getPresences()

### DIFF
--- a/lib/presence/getPresences.js
+++ b/lib/presence/getPresences.js
@@ -1,6 +1,5 @@
 // Includes
 const http = require('../util/http.js').func
-const getGeneralToken = require('../util/getGeneralToken.js').func
 
 // Args
 exports.required = ['userIds']
@@ -8,7 +7,7 @@ exports.optional = []
 
 // Docs
 /**
- * 🔐 Get the presence status of users.
+ * 🔓 Get the presence status of users; game data visibility is dependent on the privacy settings of the target user
  * @category Presence
  * @alias getPresences
  * @param {Array<number>} userIds - An array of userIds.
@@ -19,7 +18,7 @@ exports.optional = []
 **/
 
 // Define
-function getPresences (userIds, jar, xcsrf) {
+exports.func = function getPresences ({ userIds, jar }) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
       url: '//presence.roblox.com/v1/presence/users',
@@ -28,7 +27,6 @@ function getPresences (userIds, jar, xcsrf) {
         resolveWithFullResponse: true,
         jar: jar,
         headers: {
-          'X-CSRF-TOKEN': xcsrf,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
@@ -52,12 +50,4 @@ function getPresences (userIds, jar, xcsrf) {
       })
       .catch(error => reject(error))
   })
-}
-
-exports.func = function (args) {
-  const jar = args.jar
-  return getGeneralToken({ jar: jar })
-    .then(function (xcsrf) {
-      return getPresences(args.userIds, args.jar, xcsrf)
-    })
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1934,7 +1934,7 @@ declare module "noblox.js" {
     function getPlayerThumbnail(userIds: number | number[], size: BodySizes | BustSizes | HeadshotSizes, format?: "png" | "jpeg", isCircular?: boolean, cropType?: "body" | "bust" | "headshot"): Promise<PlayerThumbnailData[]>;
 
     /**
-     * 🔐 Gets the presence statuses of the specified users
+     * 🔓 Get the presence status of users; game data visibility is dependent on the privacy settings of the target user
      */
     function getPresences(userIds: number[]): Promise<Presences>;
 


### PR DESCRIPTION
Supercedes PR #543.

The CSRF token has been removed but the cookie is necessary to access private game data; documentation has also been updated to reflect this change.

![image](https://user-images.githubusercontent.com/34300238/157593702-4df19983-abf5-4d2a-a517-de2441d67687.png)
