### PR TITLE
make getPresences return an array directly

### DIFF
--- a/lib/presence/getPresences.js
+++ b/lib/presence/getPresences.js
@@ -50,11 +50,11 @@ exports.func = function getPresences ({ userIds, jar }) {
           }
           reject(new Error(error))
         } else {
-          const d = responseData.userPresences;
+          const d = responseData.userPresences
           // Slightly hacky, but preserves backwards compatibility while allowing
           // us to return an array - which makes more sense.
           // Does not affect iteration but does appear in console.log.
-          d.userPresences = d;
+          d.userPresences = d
           resolve(d)
         }
       })

--- a/lib/presence/getPresences.js
+++ b/lib/presence/getPresences.js
@@ -8,10 +8,15 @@ exports.optional = []
 // Docs
 /**
  * 🔓 Get the presence status of users; game data visibility is dependent on the privacy settings of the target user
+ *
+ * **Note**: This method used to return an object with key 'userPresences', but now returns an array of presences.
+ * To preserve backwards compatibility, this array has a key "userPresences", which is a self-reference.
+ * Do not use this key for new work. It **will** be removed in the next semver Major change.
+ * This key appears in Array.toString, but does not affect iteration.
  * @category Presence
  * @alias getPresences
  * @param {Array<number>} userIds - An array of userIds.
- * @returns {Promise<Presences>}
+ * @returns {Promise<UserPresence[]>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * const presences = await noblox.getPresences([1, 2, 3])
@@ -45,7 +50,12 @@ exports.func = function getPresences ({ userIds, jar }) {
           }
           reject(new Error(error))
         } else {
-          resolve(responseData)
+          const d = responseData.userPresences;
+          // Slightly hacky, but preserves backwards compatibility while allowing
+          // us to return an array - which makes more sense.
+          // Does not affect iteration but does appear in console.log.
+          d.userPresences = d;
+          resolve(d)
         }
       })
       .catch(error => reject(error))

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -710,7 +710,7 @@ declare module "noblox.js" {
     type PlayableDevices = "Computer" | "Phone" | "Tablet" | "Console"
     type Regions = "Unknown" | "China"
 
-    interface UniverseAsset 
+    interface UniverseAsset
     {
         assetID: number,
         assetTypeID: number,
@@ -736,7 +736,7 @@ declare module "noblox.js" {
         universeAnimationType?: AnimationType;
         universeCollisionType?: CollisionType;
         universeJointPositioningType?: JointType;
-        
+
         isArchived?: boolean;
         isFriendsOnly?: boolean;
 
@@ -747,7 +747,7 @@ declare module "noblox.js" {
 
         isForSale?: boolean;
         price?: number;
-        
+
         universeAvatarMinScales?: AvatarScale
         universeAvatarMaxScales?: AvatarScale
 
@@ -1201,9 +1201,7 @@ declare module "noblox.js" {
         oldNames?: string[];
         isBanned: boolean;
     }
-    interface Presences {
-        userPresences: UserPresence[]
-    }
+
 
     interface PlayerThumbnailData {
         targetId: number;
@@ -1936,7 +1934,7 @@ declare module "noblox.js" {
     /**
      * 🔓 Get the presence status of users; game data visibility is dependent on the privacy settings of the target user
      */
-    function getPresences(userIds: number[]): Promise<Presences>;
+    function getPresences(userIds: number[]): Promise<UserPresence[]>;
 
     /**
      * ✅ Gets the `status` message of the user with the ID `userId`.

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -909,7 +909,7 @@ type UniverseSettings = {
     universeAnimationType?: "Standard" | "PlayerChoice";
     universeCollisionType?: "InnerBox" | "OuterBox";
     universeJointPositioningType?: "Standard" | "ArtistIntent";
-    
+
     isArchived?: boolean;
     isFriendsOnly?: boolean;
 
@@ -923,7 +923,7 @@ type UniverseSettings = {
 
     isForSale?: boolean;
     price?: number;
-    
+
     universeAvatarMinScales?: AvatarScale;
     universeAvatarMaxScales?: AvatarScale;
 
@@ -951,7 +951,7 @@ type UniverseSettings = {
     universeAnimationType?: "Standard" | "PlayerChoice";
     universeCollisionType?: "InnerBox" | "OuterBox";
     universeJointPositioningType?: "Standard" | "ArtistIntent";
-    
+
     isArchived?: boolean;
     isFriendsOnly?: boolean;
 
@@ -965,7 +965,7 @@ type UniverseSettings = {
 
     isForSale?: boolean;
     price?: number;
-    
+
     universeAvatarMinScales?: AvatarScale;
     universeAvatarMaxScales?: AvatarScale;
 
@@ -1535,9 +1535,6 @@ type PlayerInfo = {
 /**
  * @typedef
 */
-type Presences = {
-    userPresences: Array<UserPresence>;
-}
 
 /**
  * @typedef


### PR DESCRIPTION
Features a slightly... dubious... hack for backwards compatibility.

Proof of concept:
```js
const arr = [1,2,3,4];
arr.foo = "bar";
arr.push(5);

for (const i of arr) {
  console.log(i);
}
```

![image](https://user-images.githubusercontent.com/25391241/158040271-5cefbbe3-f17c-4e45-9018-f08212b5ee11.png)

This key exists soley for backwards compatibility, and is intentionally not in the typescript typings. Do not use it for new work; it should be removed, if merged, in the next semver major version.