### PR TITLE
Adding await to uploadItem to JSDoc function example

### DIFF
--- a/lib/asset/uploadItem.js
+++ b/lib/asset/uploadItem.js
@@ -19,7 +19,7 @@ exports.optional = ['groupId', 'jar']
  * @example const noblox = require("noblox.js")
  * const fs = require("fs")
  * // Login using your cookie
- * noblox.uploadItem("A cool decal.", 13, fs.createReadStream("./Image.png"))
+ * await noblox.uploadItem("A cool decal.", 13, fs.createReadStream("./Image.png"))
 **/
 
 // Define


### PR DESCRIPTION
I know everyone loves small documentation edits 😄. There was some confusion in [discord](https://discord.com/channels/797610307928326194/842966507826970624/960895145971167322) due to this not having an await in the JSDoc example. Adding that to prevent that.