### PR TITLE
Add error handling to event docs

### DIFF
--- a/lib/chat/onNewConversation.js
+++ b/lib/chat/onNewConversation.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when a conversation is created.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onNewConversation().on("data", function(data) {
- *  console.log("New conversation!", data)
+ * const conversationEvent = noblox.onNewConversation()
+ * conversationEvent.on("data", function(data) {
+ *  console.log("New conversation! ", data)
+ * })
+ * conversationEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/chat/onNewMessage.js
+++ b/lib/chat/onNewMessage.js
@@ -6,14 +6,22 @@ exports.optional = ['jar']
 
 // Docs
 /**
- * 🔐 An event for when someone messages you.
+ * 🔐 An event for when someone messages you via. chat. This event will only emit for messages sent via. chat windows on
+ * the website - those in the pop-up/overlay window. To handle messages sent via. the older email-like
+ * message function, see onMessage.
+ * @see [onMessage()](global.html#onMessage)
  * @category Chat
  * @alias onNewMessage
  * @returns An EventEmitter that emits when someone messages you.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onNewMessage().on("data", function(data) {
- *  console.log("New message!", data)
+ * const messageEvent = noblox.onNewMessage()
+ * messageEvent.on("data", function(data) {
+ *  console.log("New chat message! ", data)
+ * })
+ * messageEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/chat/onNewMessageBySelf.js
+++ b/lib/chat/onNewMessageBySelf.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when you send a new message.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onNewMessageBySelf().on("data", function(data) {
- *  console.log("Sent message!", data)
+ * const messageSent = noblox.onNewMessageBySelf()
+ * messageSent.on("data", function(data) {
+ *  console.log("Sent chat message! ", data)
+ * })
+ * messageSent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/chat/onUserOnline.js
+++ b/lib/chat/onUserOnline.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when someone comes online.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onUserOnline().on("data", function(data) {
- *  console.log("User online!", data)
+ * const userOnlineEvent = noblox.onUserOnline()
+ * userOnlineEvent.on("data", function(data) {
+ *  console.log("User online! ", data)
+ * })
+ * userOnlineEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/chat/onUserTyping.js
+++ b/lib/chat/onUserTyping.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when someone starts typing in a chat.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onUserTyping().on("data", function(data) {
- *  console.log("User typing!", data)
+ * const userTyping = noblox.onUserTyping()
+ * userTyping.on("data", function(data) {
+ *  console.log("User typing! ", data)
+ * })
+ * userTyping.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/group/onAuditLog.js
+++ b/lib/group/onAuditLog.js
@@ -15,8 +15,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when an action is added to the audit log.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onAuditLog().on("data", function(data) {
+ * const auditEvent = noblox.onAuditLog(1)
+ * auditEvent.on("data", function(data) {
  *  console.log("New action!", data)
+ * })
+ * auditEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/group/onGroupTransaction.js
+++ b/lib/group/onGroupTransaction.js
@@ -21,8 +21,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when a transaction is made.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onGroupTransaction(1).on("data", function(data) {
+ * const transactionEvent = noblox.onGroupTransaction(1)
+ * transactionEvent.on("data", function(data) {
  *  console.log("New Transaction!", data)
+ * })
+ * transactionEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
  **/
 

--- a/lib/group/onShout.js
+++ b/lib/group/onShout.js
@@ -15,8 +15,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when someone shouts.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onShout(1).on("data", function(data) {
- *  console.log("New shout!", data)
+ * const shoutEvent = noblox.onShout(1)
+ * shoutEvent.on("data", function(data) {
+ *  console.log("New Shout!", data)
+ * })
+ * shoutEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/group/onWallPost.js
+++ b/lib/group/onWallPost.js
@@ -15,8 +15,13 @@ exports.optional = ['view', 'jar']
  * @returns An EventEmitter that emits when someone posts on the group wall.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onWallPost().on("data", function(data) {
+ * const wallpostEvent = noblox.onWallPost(1)
+ * wallpostEvent.on("data", function(data) {
  *  console.log("New post!", data)
+ * })
+ * wallpostEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartyDeleted.js
+++ b/lib/party/onPartyDeleted.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when a party is deleted.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartyDeleted().on("data", function(data) {
- *  console.log("Party deleted!", data)
+ * const partyDeleted = noblox.onPartyDeleted()
+ * partyDeleted.on("data", function(data) {
+ *  console.log("Party deleted! ", data)
+ * })
+ * partyDeleted.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartyInvite.js
+++ b/lib/party/onPartyInvite.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when you're invited to a party.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartyInvite().on("data", function(data) {
- *  console.log("Invited to party!", data)
+ * const partyInvite = noblox.onPartyInvite()
+ * partyInvite.on("data", function(data) {
+ *  console.log("Invited to party! ", data)
+ * })
+ * partyInvite.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartyJoinedGame.js
+++ b/lib/party/onPartyJoinedGame.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when a party joins a game.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartyJoinedGame().on("data", function(data) {
- *  console.log("Party joined game!", data)
+ * const partyJoinedGame = noblox.onPartyJoinedGame()
+ * partyJoinedGame.on("data", function(data) {
+ *  console.log("Party joined game! ", data)
+ * })
+ * partyJoinedGame.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartyLeftGame.js
+++ b/lib/party/onPartyLeftGame.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when a party leaves a game.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartyLeftGame().on("data", function(data) {
- *  console.log("Party left game!", data)
+ * const partyLeftGame = noblox.onPartyLeftGame()
+ * partyLeftGame.on("data", function(data) {
+ *  console.log("Party left game! ", data)
+ * })
+ * partyLeftGame.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartySelfJoined.js
+++ b/lib/party/onPartySelfJoined.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when you join a party.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartySelfJoined().on("data", function(data) {
- *  console.log("You joined a party!", data)
+ * const joinedParty = noblox.onPartySelfJoined()
+ * joinedParty.on("data", function(data) {
+ *  console.log("You joined a party! ", data)
+ * })
+ * joinedParty.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartySelfLeft.js
+++ b/lib/party/onPartySelfLeft.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when you leave a party.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartySelfLeft().on("data", function(data) {
- *  console.log("You left a party!", data)
+ * const leftParty = noblox.onPartySelfLeft()
+ * leftParty.on("data", function(data) {
+ *  console.log("You left a party! ", data)
+ * })
+ * leftParty.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartyUserJoined.js
+++ b/lib/party/onPartyUserJoined.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when someone joins a party.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartyUserJoined().on("data", function(data) {
- *  console.log("Someone joined a party!", data)
+ * const partyJoined = noblox.onPartyUserJoined()
+ * partyJoined.on("data", function(data) {
+ *  console.log("Someone joined a party! ", data)
+ * })
+ * partyJoined.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/party/onPartyUserLeft.js
+++ b/lib/party/onPartyUserLeft.js
@@ -12,8 +12,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when someone leaves a party.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onPartyUserLeft().on("data", function(data) {
- *  console.log("User left party!", data)
+ * const partyLeft = noblox.onPartyUserLeft()
+ * partyLeft.on("data", function(data) {
+ *  console.log("Someone left party! ", data)
+ * })
+ * partyLeft.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/user/onBlurbChange.js
+++ b/lib/user/onBlurbChange.js
@@ -13,8 +13,13 @@ exports.required = ['userId']
  * @param {number} userId - The id of the user.
  * @returns An EventEmitter that emits when a user's blurb changes.
  * @example const noblox = require("noblox.js")
- * noblox.onBlurbChange().on("data", function(data) {
+ * const blurbEvent = noblox.onBlurbChange(1)
+ * blurbEvent.on("data", function(data) {
  *  console.log("User's blurb changed!", data)
+ * })
+ * blurbEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/user/onFriendRequest.js
+++ b/lib/user/onFriendRequest.js
@@ -15,8 +15,14 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when a user sends you a friend request.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onFriendRequest().on("data", function(data) {
- *  console.log("New friend request!", data)
+ *
+ * const friendRequestEvent = noblox.onFriendRequest()
+ * friendRequestEvent.on("data", function(data) {
+ *  console.log("New friend request! ", data)
+ * })
+ * friendRequestEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/user/onMessage.js
+++ b/lib/user/onMessage.js
@@ -10,14 +10,21 @@ exports.optional = ['jar']
 
 // Docs
 /**
- * 🔐 An event for when a user sends you a message.
+ * 🔐 An event for when a user sends you a message via. the older 'email-like' message system. To receive chat messages,
+ * see the `onNewMessage` method.
+ * @see [onNewMessage()](global.html#onNewMessage).
  * @category User
  * @alias onMessage
  * @returns An EventEmitter that emits when a user sends you a message.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onMessage().on("data", function(data) {
- *  console.log("New message!", data)
+ * const messageEvent = noblox.onMessage()
+ * messageEvent.on("data", function(data) {
+ *  console.log("New message! ", data)
+ * })
+ * messageEvent.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 

--- a/lib/user/onNotification.js
+++ b/lib/user/onNotification.js
@@ -17,8 +17,13 @@ exports.optional = ['jar']
  * @returns An EventEmitter that emits when you get a notification.
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
- * noblox.onNotification().on("data", function(data) {
- *  console.log("New notification!", data)
+ * const notification = noblox.onNotification()
+ * notification.on("data", function(data) {
+ *  console.log("New notification! ", data)
+ * })
+ * notification.on("error", function(err) {
+ *  console.error("Something went wrong: ", err)
+ *  // Handle error as needed
  * })
 **/
 


### PR DESCRIPTION
Fixes #527 

It's better practice to handle the errors, and it was throwing a lot of people off as the errors could crash applications if not handled correctly - sort of like an unhandled rejection.

