### PR TITLE
Check for existence of shout before parsing dates

### DIFF
--- a/lib/groups/getGroup.js
+++ b/lib/groups/getGroup.js
@@ -31,8 +31,10 @@ function getGroup (groupId) {
         if (res.statusCode === 200) {
           const body = JSON.parse(res.body)
 
-          body.shout.created = new Date(body.shout.created)
-          body.shout.updated = new Date(body.shout.updated)
+          if (body.shout) {
+            body.shout.created = new Date(body.shout.created)
+            body.shout.updated = new Date(body.shout.updated)
+          }
 
           resolve(body)
         } else {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -808,7 +808,7 @@ declare module "noblox.js" {
         name: string;
         description: string;
         owner: GroupUser;
-        shout: GroupShout | null;
+        shout?: GroupShout;
         memberCount: number;
         isBuildersClubOnly: boolean;
         publicEntryAllowed: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -808,7 +808,7 @@ declare module "noblox.js" {
         name: string;
         description: string;
         owner: GroupUser;
-        shout: GroupShout;
+        shout: GroupShout | null;
         memberCount: number;
         isBuildersClubOnly: boolean;
         publicEntryAllowed: boolean;

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -1068,7 +1068,7 @@ type Group = {
     name: string;
     description: string;
     owner: GroupUser;
-    shout: GroupShout;
+    shout: GroupShout | null;
     memberCount: number;
     isBuildersClubOnly: boolean;
     publicEntryAllowed: boolean;

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -1068,7 +1068,7 @@ type Group = {
     name: string;
     description: string;
     owner: GroupUser;
-    shout: GroupShout | null;
+    shout?: GroupShout;
     memberCount: number;
     isBuildersClubOnly: boolean;
     publicEntryAllowed: boolean;


### PR DESCRIPTION
The `shout` property is null for groups that have never set a shout.