### PR TITLE
Fixed getGroup (cannot read properties of null 'created')

### DIFF
--- a/lib/groups/getGroup.js
+++ b/lib/groups/getGroup.js
@@ -31,8 +31,10 @@ function getGroup (groupId) {
         if (res.statusCode === 200) {
           const body = JSON.parse(res.body)
 
-          body.shout.created = new Date(body.shout.created)
-          body.shout.updated = new Date(body.shout.updated)
+          if (body.shout) {
+            body.shout.created = new Date(body.shout.created)
+            body.shout.updated = new Date(body.shout.updated)
+          }
 
           resolve(body)
         } else {


### PR DESCRIPTION
Fixed the getGroup function not working if shout is null