### PR TITLE
Update Docs getUniverseInfo()

### DIFF
--- a/lib/games/getUniverseInfo.js
+++ b/lib/games/getUniverseInfo.js
@@ -9,7 +9,7 @@ exports.optional = ['jar']
  * @category Game
  * @alias getUniverseInfo
  * @param {number | Array<number>} universeId - The id(s) of the universe(s).
- * @returns {Promise<UniverseInformation>}
+ * @returns {Promise<UniverseInformation[]>}
  * @example const noblox = require("noblox.js")
  * const universeInfo = await noblox.getUniverseInfo([ 2152417643 ])
 **/

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1842,7 +1842,7 @@ declare module "noblox.js" {
     /**
      * 🔓 Returns information about the universe(s) in question, such as description, name etc; varies based on whether or not you're logged in.
      */
-    function getUniverseInfo(universeIds: number[] | number, jar?: CookieJar): Promise<UniverseInformation>;
+    function getUniverseInfo(universeIds: number[] | number, jar?: CookieJar): Promise<UniverseInformation[]>;
 
     /**
      * 🔐 Update a developer product.


### PR DESCRIPTION
Docs originally says that getUniverseInfo() returns Promise<UniverseInformation> which was incorrect. The correct return type is Promise<UniverseInformation[]>