### PR TITLE
Fix onAuditLog

### DIFF
--- a/lib/groups/getAuditLog.js
+++ b/lib/groups/getAuditLog.js
@@ -43,7 +43,10 @@ function getAuditLog (group, actionType, userId, sortOrder, limit, cursor, jar) 
           reject(new Error(error))
         } else {
           responseData.data = responseData.data.map((entry) => {
+            // We need to set milliseconds to 0 because Roblox does this fascinating thing
+            // Where they vary the ms value on each request, for an existing action.
             entry.created = new Date(entry.created)
+            entry.created.setMilliseconds(0)
             return entry
           })
           resolve(responseData)

--- a/lib/groups/onAuditLog.js
+++ b/lib/groups/onAuditLog.js
@@ -36,10 +36,7 @@ exports.func = function (args) {
           if (audit) {
             for (const key in audit.data) {
               if (Object.prototype.hasOwnProperty.call(audit.data, key)) {
-                // We need to set milliseconds to 0 because Roblox does this fascinating thing
-                // Where they vary the ms value on each request, for an existing action.
                 const date = audit.data[key].created
-                date.setMilliseconds(0)
 
                 if (date > latest) {
                   latest = date

--- a/lib/groups/onAuditLog.js
+++ b/lib/groups/onAuditLog.js
@@ -36,7 +36,11 @@ exports.func = function (args) {
           if (audit) {
             for (const key in audit.data) {
               if (Object.prototype.hasOwnProperty.call(audit.data, key)) {
-                const date = new Date(audit.data[key].created.slice(0, audit.data[key].created.lastIndexOf('.')))
+                // We need to set milliseconds to 0 because Roblox does this fascinating thing
+                // Where they vary the ms value on each request, for an existing action.
+                const date = audit.data[key].created
+                date.setMilliseconds(0)
+
                 if (date > latest) {
                   latest = date
                   given.push(audit.data[key])


### PR DESCRIPTION
Fixes #688 
When it was changed so that created is parsed to a date in getAuditLog, it broke onAuditLog.
We need to reset the millisecond count to 0 because Roblox does something fascinating... and varies the value on each request.