### PR TITLE
Fix validation bug.

### DIFF
--- a/lib/client/setCookie.js
+++ b/lib/client/setCookie.js
@@ -20,6 +20,9 @@ exports.optional = ['validate']
 
 exports.func = async function (args) {
   // verify it
+  
+  args.cookie = args.cookie.replace(/\r?\n|\r/g, '');
+  
   if (!args.cookie.toLowerCase().includes('warning:-')) {
     console.error('Warning: No Roblox warning detected in provided cookie. Ensure you include the entire .ROBLOSECURITY warning.')
   }


### PR DESCRIPTION
I have no idea what the bug is caused by but people may recieve false positives for cookie validation. This fixes it by replacing any invalid character with empty space. It does not remove any letters of anything required for authentication.

I've experienced this bug with the following devices + editors:
Linux (Crostini OS) - GNU Nano;
Linux (Termux/Android) - GNU Nano;