### PR TITLE
Fixed onAuditLog not working

### DIFF
--- a/lib/groups/onAuditLog.js
+++ b/lib/groups/onAuditLog.js
@@ -30,7 +30,7 @@ exports.func = function (args) {
   let empty = false
   return shortPoll({
     getLatest: function (latest) {
-      return getAuditLog({ group: args.group, jar: args.jar })
+      return getAuditLog({ group: args.group, jar: args.jar, sortOrder: "Desc" })
         .then(function (audit) {
           const given = []
           if (audit) {

--- a/lib/groups/onAuditLog.js
+++ b/lib/groups/onAuditLog.js
@@ -30,7 +30,7 @@ exports.func = function (args) {
   let empty = false
   return shortPoll({
     getLatest: function (latest) {
-      return getAuditLog({ group: args.group, jar: args.jar, sortOrder: "Desc" })
+      return getAuditLog({ group: args.group, jar: args.jar, sortOrder: 'Desc' })
         .then(function (audit) {
           const given = []
           if (audit) {


### PR DESCRIPTION
Added sortOrder argument to return the newest audit logs rather than only fetching the oldest ones, resulting in nothing coming through when using onAuditLog.
Sort order default being ascending resulted in the API request only returning the first 100 or so audit logs from the group.