### PR TITLE
 Update updateDeveloperProduct function to new 'apis.' endpoint; removes iconImageAssetId parameter (needs new method call)

### DIFF
--- a/lib/games/updateDeveloperProduct.js
+++ b/lib/games/updateDeveloperProduct.js
@@ -2,7 +2,7 @@ const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
 
 exports.required = ['universeId', 'productId', 'priceInRobux']
-exports.optional = ['name', 'description', 'iconImageAssetId', 'jar']
+exports.optional = ['name', 'description', 'jar']
 
 // Docs
 /**
@@ -14,17 +14,16 @@ exports.optional = ['name', 'description', 'iconImageAssetId', 'jar']
  * @param {number} priceInRobux - The new price of the product.
  * @param {string=} name - The new name of the product.
  * @param {string=} description - The new description of the product.
- * @param {iconImageAssetId=} iconImageAssetId - The new icon image asset ID for the product.
  * @returns {Promise<void>}
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * noblox.updateDeveloperProduct(1, 2, 10, "An Updated Developer Product", "My new updated product.")
 **/
 
-function updateDeveloperProduct (universeId, productId, priceInRobux, name, description, iconImageAssetId, jar, token) {
+function updateDeveloperProduct(universeId, productId, priceInRobux, name, description, jar, token) {
   return new Promise((resolve, reject) => {
     return http({
-      url: `//develop.roblox.com/v1/universes/${universeId}/developerproducts/${productId}/update`,
+      url: `//apis.roblox.com/developer-products/v1/universes/${universeId}/developerproducts/${productId}/update`,
       options: {
         method: 'POST',
         jar: jar,
@@ -34,7 +33,6 @@ function updateDeveloperProduct (universeId, productId, priceInRobux, name, desc
         json: {
           Name: name,
           Description: description,
-          IconImageAssetId: iconImageAssetId,
           PriceInRobux: priceInRobux
         },
         resolveWithFullResponse: true
@@ -46,14 +44,12 @@ function updateDeveloperProduct (universeId, productId, priceInRobux, name, desc
         reject(new Error(`[${statusCode}] ${body.errors[0].message} | universeId: ${universeId}, body: ${JSON.stringify({
           Name: name,
           Description: description,
-          IconImageAssetId: iconImageAssetId,
           PriceInRobux: priceInRobux
         })}`))
       } else {
         reject(new Error(`An unknown error occurred with updateDeveloperProduct() | [${statusCode}] universeId: ${universeId}, body: ${JSON.stringify({
           Name: name,
           Description: description,
-          IconImageAssetId: iconImageAssetId,
           PriceInRobux: priceInRobux
         })}`))
       }
@@ -61,9 +57,9 @@ function updateDeveloperProduct (universeId, productId, priceInRobux, name, desc
   })
 }
 
-exports.func = function ({ universeId, productId, priceInRobux, name, description, iconImageAssetId, jar }) {
+exports.func = function ({ universeId, productId, priceInRobux, name, description, jar }) {
   return getGeneralToken({ jar })
     .then((token) => {
-      return updateDeveloperProduct(universeId, productId, priceInRobux, name, description, iconImageAssetId, jar, token)
+      return updateDeveloperProduct(universeId, productId, priceInRobux, name, description, jar, token)
     })
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1879,7 +1879,7 @@ declare module "noblox.js" {
     /**
      * 🔐 Update a developer product.
      */
-    function updateDeveloperProduct(universeId: number, productId: number, priceInRobux: number, name?: string, description?: string, iconImageAssetId?: number, jar?: CookieJar): Promise<void>;
+    function updateDeveloperProduct(universeId: number, productId: number, priceInRobux: number, name?: string, description?: string, jar?: CookieJar): Promise<void>;
 
     /// Groups
     /**


### PR DESCRIPTION
The endpoint currently referenced by `updateDeveloperProduct` is deprecated and responds with a HTTP 404; this change updates the method to match what is used by the website.

This introduces a breaking change since `iconImageAssetId` is no longer supported. I recommend we create a new method for updating the icon rather than nesting the request inside this method; especially since the website is now required a full FormData upload instead of creating a decal and referencing it's `assetId`.