### PR TITLE
Removed token parameter which prevented the function from respecting custom parameter values

### DIFF
--- a/lib/client/onNotification.js
+++ b/lib/client/onNotification.js
@@ -1,5 +1,5 @@
 // Dependencies
-const SignalR = require('signalr-client').client
+const signalR = require('@microsoft/signalr')
 const events = require('events')
 
 // Includes
@@ -36,34 +36,50 @@ exports.func = function (args) {
       args.jar = { session: args.jar }
     }
     const session = getSession({ jar: args.jar })
-    const client = new SignalR('wss://realtime.roblox.com/notifications', ['usernotificationhub'], 3, true) // wss for https
-    client.headers.Cookie = '.ROBLOSECURITY=' + session + ';'
-    client.on('usernotificationhub', 'notification', function (name, message) {
-      notifications.emit('data', name, JSON.parse(message))
-    })
-    notifications.on('close', client.end)
-    client.serviceHandlers.connectFailed = function (err) {
-      notifications.emit('error', new Error('Connection failed: ' + err.message))
-      if (retries !== -1) {
-        if (retries > max) {
-          notifications.emit('close', new Error('Max retries reached'))
-        } else {
-          setTimeout(connect, 5000, retries + 1)
+    let userNotificationConnection = null;
+
+    userNotificationConnection = new signalR.HubConnectionBuilder()
+      .withUrl('https://realtime-signalr.roblox.com/userhub', {
+        transport: signalR.HttpTransportType.WebSockets,
+        skipNegotiation: true,
+        headers: {
+          Cookie: '.ROBLOSECURITY=' + session + ';'
+        }
+      })
+      .build();
+
+      userNotificationConnection.on('notification', function(name, message) {
+        notifications.emit('data', name, JSON.parse(message))
+      })
+
+      notifications.on('close', userNotificationConnection.stop)
+
+      userNotificationConnection.disconnected = function (err) {
+        notifications.emit('error', new Error('Connection failed: ' + err.message))
+        if (retries !== -1) {
+          if (retries > max) {
+            notifications.emit('close', new Error('Max retries reached'))
+          } else {
+            setTimeout(connect, 5000, retries + 1)
+          }
         }
       }
-    }
-    client.serviceHandlers.onerror = function (err) {
-      notifications.emit('error', err)
-    }
-    client.serviceHandlers.connected = function (connection) {
-      notifications.emit('connect', connection)
-    }
-    client.serviceHandlers.reconnecting = function () {
-      setTimeout(connect, 5000, 0)
+
+      userNotificationConnection.error = function (err) {
+        notifications.emit('error', err)
+      }
+
+      userNotificationConnection.connected = function(connection) {
+        notifications.emit('connect', connection)
+      }
+
+      userNotificationConnection.reconnecting = function () {
+        setTimeout(connect, 5000, 0)
       notifications.emit('error', new Error('Lost connection, reconnecting'))
       return true // Abort reconnection
-    }
-    client.start()
+      }
+
+      userNotificationConnection.start()
   }
   connect(-1)
   return notifications

--- a/lib/privatemessages/getMessages.js
+++ b/lib/privatemessages/getMessages.js
@@ -19,13 +19,13 @@ exports.optional = ['pageNumber', 'pageSize', 'messageTab', 'jar']
 **/
 
 // Define
-function getMessages (jar, token, pageNumber, pageSize, messageTab) {
+function getMessages (jar, pageNumber, pageSize, messageTab) {
   return new Promise((resolve, reject) => {
     const httpOpt = {
       url: `//privatemessages.roblox.com/v1/messages?pageNumber=${pageNumber}&pageSize=${pageSize}&messageTab=${messageTab}`,
       options: {
         method: 'GET',
-        jar,
+        jar: jar,
         resolveWithFullResponse: true
       }
     }

--- a/lib/privatemessages/onMessage.js
+++ b/lib/privatemessages/onMessage.js
@@ -55,7 +55,6 @@ exports.func = function (args) {
                   const message = messages[i]
                   const id = message.id
                   if (id > latest) {
-                    console.log(id)
                     latest = id
                     onMessage.emit('data', message)
                   }

--- a/lib/privatemessages/onMessage.js
+++ b/lib/privatemessages/onMessage.js
@@ -34,19 +34,20 @@ exports.func = function (args) {
   const onMessage = new events.EventEmitter()
   let waitingForRequest = false
   let latest
-  getMessages({ jar, messageTab: 'Inbox', pageNumber: 0 })
+  getMessages({ jar: jar, messageTab: 'Inbox', pageNumber: 0, pageSize: 1 })
     .then(function (initial) {
       latest = initial.collection[0] ? initial.collection[0].id : 0
-      const notifications = onNotification({ jar })
+      const notifications = onNotification({ jar: jar })
       notifications.on('data', function (name, message) {
-        if (name === 'NotificationStream' && message.Type === 'NewNotification') {
+        if (name === 'MessageNotification' && message.Type === 'Created') {
           if (waitingForRequest) {
             waitingForRequest = false
           } else {
             getMessages({
-              jar,
+              jar: jar,
               messageTab: 'Inbox',
-              pageNumber: 0
+              pageNumber: 0,
+              pageSize: 1
             })
               .then(function (inbox) {
                 const messages = inbox.collection
@@ -54,6 +55,7 @@ exports.func = function (args) {
                   const message = messages[i]
                   const id = message.id
                   if (id > latest) {
+                    console.log(id)
                     latest = id
                     onMessage.emit('data', message)
                   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "clans"
   ],
   "dependencies": {
+    "@microsoft/signalr": "^8.0.0",
     "chalk": "^4.0.0",
     "cheerio": "^1.0.0-rc.10",
     "entities": "^4.3.0",
@@ -41,7 +42,6 @@
   "homepage": "https://github.com/noblox/noblox.js",
   "devDependencies": {
     "@auto-it/conventional-commits": "^10.30.0",
-    "JSONStream": "^1.3.1",
     "auto": "^10.30.0",
     "better-docs": "2.7.2",
     "dotenv": "16.0.3",
@@ -54,6 +54,7 @@
     "jest": "^29.5.0",
     "jest-extended": "^3.2.4",
     "jsdoc": "3.6.10",
+    "JSONStream": "^1.3.1",
     "progress": "^2.0.0",
     "standard": "^17.0.0"
   },


### PR DESCRIPTION
Before when you would retrieve messages, it would use the default parameter values no matter what you put when you use the function. Ex. if you change the messageTab, pageSize, or pageNumber it would only use the default values. Therefore, I removed the undefined parameter to fix it. I also added the jar: jar back because it seems to work fine with it.

I also Fixed the onMessage event where it wouldn't get messages due to change in notification name and message type. I had to add the pageSize parameter and set it to 1 so it will get the latest message because before it was sending 25 messages at a time when the event is called which is also why I had to remove the token parameter in the getMessages file because it wouldn't let me set the pageSize.

I Fixed the onNotification issue that was using a deprecated signalr package and has switched over to @microsoft/signalr.
I updated the package.json file to include the change in the dependency.