### PR TITLE
Added postToTopic() for MessagingService needs

### DIFF
--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -13,8 +13,9 @@ exports.optional = ['jar']
  * @param {Object | string} data - The data to post.
  * @returns {Promise<boolean>}
  * @example const noblox = require("noblox.js")
- * const data = { targetUser: "1210019099" }
- * await noblox.publishToTopic(2152417643, "MyTopic", data)
+ * const data = { targetUser: 123456789, staffMember: 1210019099, action: "Kick" }
+ *
+ * await noblox.publishToTopic(2152417643, "ModerateUser", data)
 **/
 
 function publishToTopic (universeId, topic, data, jar) {
@@ -38,10 +39,11 @@ function publishToTopic (universeId, topic, data, jar) {
       .then(function ({ statusCode }) {
         switch (statusCode) {
           case 200: resolve(true)
-          case 400: reject(new Error(`[${statusCode}] Bad Request, check what data is being sent`))
-          case 401: reject(new Error(`[${statusCode}] Unauthorized`))
+          case 400: reject(new Error(`[${statusCode}] Bad Request, recheck the data being sent`))
+          case 401: reject(new Error(`[${statusCode}] Unauthorized | universeId: ${universeId}`))
           case 403: reject(new Error(`[${statusCode}] Forbidden, possible insufficient API key access permissions`))
           case 500: reject(new Error(`[${statusCode}] Internal server error`))
+          default: reject(new Error(`[${statusCode}] Unknown error | universeId: ${universeId} topic: ${topic}`))
         }
       }).catch(reject)
   })

--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -37,14 +37,17 @@ function publishToTopic (universeId, topic, data, jar) {
 
     return http(httpOpt)
       .then(function ({ statusCode }) {
-        switch (statusCode) {
-          case 200: resolve(true)
-          case 400: reject(new Error(`[${statusCode}] Bad Request, recheck the data being sent`))
-          case 401: reject(new Error(`[${statusCode}] Unauthorized | universeId: ${universeId}`))
-          case 403: reject(new Error(`[${statusCode}] Forbidden, possible insufficient API key access permissions`))
-          case 500: reject(new Error(`[${statusCode}] Internal server error`))
-          default: reject(new Error(`[${statusCode}] Unknown error | universeId: ${universeId} topic: ${topic}`))
-        }
+          if (statusCode === 200) {
+            resolve(true)
+          } else if (statusCode === 400) {
+            reject(new Error(`[${statusCode}] Bad Request, recheck the data being sent`))
+          } else if (statusCode === 401) {
+            reject(new Error(`[${statusCode}] Unauthorized | universeId: ${universeId}`))
+          } else if (statusCode === 403) {
+            reject(new Error(`[${statusCode}] Forbidden, possible insufficient API key access permissions`))
+          } else {
+            reject(new Error(`[${statusCode}] Unknown error | universeId: ${universeId} topic: ${topic}`))
+          }
       }).catch(reject)
   })
 }

--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -40,7 +40,7 @@ function publishToTopic (universeId, topic, data, jar) {
           case 200: resolve(true)
           case 400: reject(new Error(`[${statusCode}] Bad Request, check what data is being sent`))
           case 401: reject(new Error(`[${statusCode}] Unauthorized`))
-          case 403: reject(new Error(`[${statusCode}] Forbidden, Possible insufficient API key access permissions`))
+          case 403: reject(new Error(`[${statusCode}] Forbidden, possible insufficient API key access permissions`))
           case 500: reject(new Error(`[${statusCode}] Internal server error`))
         }
       }).catch(reject)

--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -1,0 +1,52 @@
+const http = require('../util/http.js').func
+
+exports.required = ['universeId', 'topic', 'data']
+exports.optional = ['jar']
+
+// Docs
+/**
+ * ☁️ Publish a message to a subscribed topic.
+ * @category Game
+ * @alias postToTopic
+ * @param {number} universeId - The id of the universe.
+ * @param {string} topic - The name of the topic.
+ * @param {Object | string} data - The data to post.
+ * @returns {Promise<boolean>}
+ * @example const noblox = require("noblox.js")
+ * const data = { targetUser: "1210019099" }
+ * await noblox.publishToTopic(2152417643, "MyTopic", data)
+**/
+
+function publishToTopic (universeId, topic, data, jar) {
+  return new Promise((resolve, reject) => {
+
+    const httpOpt = {
+      url: `//apis.roblox.com/messaging-service/v1/universes/${universeId}/topics/${topic}`,
+      options: {
+        json: true,
+        resolveWithFullResponse: true,
+        jar,
+        method: 'POST',
+        body: { 'message': JSON.stringify(data) },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    }
+
+    return http(httpOpt)
+      .then(function ({ statusCode }) {
+        switch (statusCode) {
+          case 200: resolve(true)
+          case 400: reject(new Error(`[${statusCode}] Bad Request, check what data is being sent`))
+          case 401: reject(new Error(`[${statusCode}] Unauthorized`))
+          case 403: reject(new Error(`[${statusCode}] Forbidden, Possible insufficient API key access permissions`))
+          case 500: reject(new Error(`[${statusCode}] Internal server error`))
+        }
+      }).catch(reject)
+  })
+}
+
+exports.func = function (args) {
+  return publishToTopic(args.universeId, args.topic, args.data, args.jar)
+}

--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -42,7 +42,7 @@ function publishToTopic (universeId, topic, data, jar) {
           } else if (statusCode === 400) {
             reject(new Error(`[${statusCode}] Bad Request, recheck the data being sent`))
           } else if (statusCode === 401) {
-            reject(new Error(`[${statusCode}] Unauthorized | universeId: ${universeId}`))
+            reject(new Error(`[${statusCode}] Unauthorized, possible invalid API key`))
           } else if (statusCode === 403) {
             reject(new Error(`[${statusCode}] Forbidden, possible insufficient API key access permissions`))
           } else {

--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -23,32 +23,32 @@ function publishToTopic (universeId, topic, data, jar) {
 
     const httpOpt = {
       url: `//apis.roblox.com/messaging-service/v1/universes/${universeId}/topics/${topic}`,
-      options: {
-        json: true,
-        resolveWithFullResponse: true,
-        jar,
-        method: 'POST',
-        body: { 'message': JSON.stringify(data) },
-        headers: {
-          'Content-Type': 'application/json'
+        options: {
+          json: true,
+          resolveWithFullResponse: true,
+          jar,
+          method: 'POST',
+          body: { message: JSON.stringify(data) },
+          headers: {
+            'Content-Type': 'application/json'
+          }
         }
-      }
     }
 
-    return http(httpOpt)
-      .then(function ({ statusCode }) {
-          if (statusCode === 200) {
-            resolve(true)
-          } else if (statusCode === 400) {
-            reject(new Error(`[${statusCode}] Bad Request, recheck the data being sent`))
-          } else if (statusCode === 401) {
-            reject(new Error(`[${statusCode}] Unauthorized, possible invalid API key`))
-          } else if (statusCode === 403) {
-            reject(new Error(`[${statusCode}] Forbidden, possible insufficient API key access permissions`))
-          } else {
-            reject(new Error(`[${statusCode}] Unknown error | universeId: ${universeId} topic: ${topic}`))
-          }
-      }).catch(reject)
+  return http(httpOpt)
+    .then(function (res) {
+      if (res.statusCode === 200) {
+        resolve(true)
+      } else {
+        if (typeof(res.body) === "string") {
+          reject(new Error(`[${res.statusCode}] ${res.statusMessage} ${res.body}`))
+        } else {
+          const data = Object.assign(res.body)
+          reject(new Error(`[${res.statusCode}] ${data.Error} ${data.Message}`))
+        }
+      }
+    })
+    .catch(reject)
   })
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -736,7 +736,7 @@ declare module "noblox.js" {
         isFavoritedByUser: boolean;
         favoritedCount: number;
     }
-            
+
     interface PlaceInformation {
         placeId: number;
         name: string;
@@ -1670,12 +1670,12 @@ declare module "noblox.js" {
 
     /// DataStores
 
-    /** 
-     * ☁️ Marks the entry as deleted by creating a tombstone version. Entries are deleted permanently after 30 days. 
+    /**
+     * ☁️ Marks the entry as deleted by creating a tombstone version. Entries are deleted permanently after 30 days.
      */
     function deleteDatastoreEntry(universeId: number, datastoreName: string, entryKey: string, scope?: string, jar?: CookieJar): Promise<void>
 
-    /** 
+    /**
      * ☁️ Returns the latest value and metadata associated with an entry, or a specific version if versionId is provided.
      */
     function getDatastoreEntry(universeId: number, datastoreName: string, entryKey: string, scope?: string, versionId?: string, jar?: CookieJar): Promise<DatastoreEntry>
@@ -1821,7 +1821,7 @@ declare module "noblox.js" {
     /// Games
 
     /**
-     * 🔐 Adds a developer product to the specified universe. 
+     * 🔐 Adds a developer product to the specified universe.
      * Warning: The `productId` returned by this function does not match the `productId` used by other endpoints.
      */
     function addDeveloperProduct(universeId: number, name: string, priceInRobux: number, description?: string, jar?: CookieJar): Promise<DeveloperProductAddResult>;
@@ -1871,11 +1871,16 @@ declare module "noblox.js" {
      */
     function getUniverseInfo(universeIds: number[] | number, jar?: CookieJar): Promise<UniverseInformation[]>;
 
-    /** 
+    /**
+    * ☁️ Publish a message to a subscribed topic.
+    */
+    function publishToTopic(universeId: number, topic: string, data: (Object | string), jar?: CookieJar): Promise<boolean>;
+
+    /**
      * 🔐 Returns information about the place(s) in question, such as name, description, etc.
      */
     function getPlaceInfo(placeIds: number[] | number, jar?: CookieJar): Promise<PlaceInformation[]>;
-            
+
     /**
      * 🔐 Update a developer product.
      */


### PR DESCRIPTION
Requires user to have set their API key. The API key requires access permission `Messaging Service API` and its operation `Publish`.
![image](https://github.com/noblox/noblox.js/assets/51011212/9d10cabd-9989-4f8d-bf5f-ea7033b9030c)

Use case example:
```js
// JavaScript

const noblox = require("noblox.js")

await noblox.setAPIKey(process.env.API_KEY)

const universeId = 4283343407
const topicName = "ModerateUser"
const data = { targetUser: 123456789, staffMember: 1210019099, action: "Kick" }

await noblox.publishToTopic(universeId, topicName, data)
```

```lua
-- Roblox Luau

local MessagingService = game:GetService("MessagingService")
local HttpService = game:GetService("HttpService")

MessagingService:SubscribeAsync("ModerateUser", function(message)
    -- The information passed in the JavaScript is placed into `Data` and needs to be decoded
    -- Types can be used here to parse the decoded data
    local data = HttpService:JSONDecode(message.Data)
	
    print(data)
end)
```

Roblox documentation:
https://create.roblox.com/docs/reference/cloud/messaging-service
https://create.roblox.com/docs/cloud/open-cloud/usage-messaging