### PR TITLE
Return more information than "not logged in" for getConversations

### DIFF
--- a/lib/chat/getConversations.js
+++ b/lib/chat/getConversations.js
@@ -43,20 +43,6 @@ exports.func = (args) => {
         return entry
       })
 
-      const nonexistentConversations = []
-
-      for (const conversation in conversationIds) {
-        if (!response.find((res) => res.id === conversation)) {
-          nonexistentConversations.push(conversation)
-        }
-      }
-
-      if (response.length < conversationIds.length) {
-        throw new Error(
-          `The following conversations do not exist: ${nonexistentConversations.join(', ')}`
-        )
-      }
-
       return response
     }
   })

--- a/lib/chat/getConversations.js
+++ b/lib/chat/getConversations.js
@@ -43,6 +43,20 @@ exports.func = (args) => {
         return entry
       })
 
+      const nonexistentConversations = []
+
+      for (const conversation in conversationIds) {
+        if (!response.find((res) => res.id === conversation)) {
+          nonexistentConversations.push(conversation)
+        }
+      }
+
+      if (response.length < conversationIds.length) {
+        throw new Error(
+          `The following conversations do not exist: ${nonexistentConversations.join(', ')}`
+        )
+      }
+
       return response
     }
   })

--- a/lib/chat/getConversations.js
+++ b/lib/chat/getConversations.js
@@ -13,7 +13,7 @@ exports.optional = ['jar']
  * @example const noblox = require("noblox.js")
  * // Login using your cookie
  * const conversations = await noblox.getConversations([1, 2, 3])
-**/
+ **/
 
 exports.func = (args) => {
   const jar = args.jar
@@ -28,7 +28,13 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      const body = JSON.parse(res.body) || {}
+      if (body.errors && body.errors.length > 0) {
+        const errors = body.errors.map((e) => {
+          return e.message
+        })
+        throw new Error(`${res.statusCode} ${errors.join(', ')}`)
+      }
     } else {
       let response = JSON.parse(res.body)
 

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -40,10 +40,6 @@ describe('Chat Methods', () => {
     await expect(getConversations([8212952828])).resolves.not.toThrow()
   })
 
-  it('getConversations() throws when one or more conversations with the provided IDs do not exist', async () => {
-    await expect(getConversations([8212952828, 0])).resolves.toThrow()
-  })
-
   it('getRolloutSettings() returns rollout settings for chat features', async () => {
     await expect(getRolloutSettings(['LuaChat', 'Party'])).resolves.not.toThrow()
   })

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -40,6 +40,10 @@ describe('Chat Methods', () => {
     await expect(getConversations([8212952828])).resolves.not.toThrow()
   })
 
+  it('getConversations() throws when one or more conversations with the provided IDs do not exist', async () => {
+    await expect(getConversations([8212952828, 0])).resolves.toThrow()
+  })
+
   it('getRolloutSettings() returns rollout settings for chat features', async () => {
     await expect(getRolloutSettings(['LuaChat', 'Party'])).resolves.not.toThrow()
   })


### PR DESCRIPTION
Currently, `getConversations()` throws the not logged in error no matter what the actual error was. Instead we should return the actual errors that Roblox returns. We should also throw in cases where one or more of the conversation IDs don't exist as to prevent any surprises.

- closes #753

At some point we should change the others as well.