### PR TITLE
Fix CSRF auto refreshing

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -87,7 +87,7 @@ exports.func = function (args) {
 
         try {
           message = typeof res.body === 'string' ? JSON.parse(res.body).message : res.body.message
-        } catch {
+        } catch (_) {
           // Roblox didn't send back a properly formed json object
         }
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -82,19 +82,32 @@ exports.func = function (args) {
   }
   return http(args.url, opt).then(function (res) {
     if (opt && opt.headers && opt.headers['X-CSRF-TOKEN']) {
-      if (res.statusCode === 403 && (res.statusMessage === 'XSRF Token Validation Failed' || res.statusMessage === 'Token Validation Failed')) {
-        depth++
-        if (depth >= 3) {
-          throw new Error('Tried ' + depth + ' times and could not refresh XCSRF token successfully')
+      if (res.statusCode === 403) {
+        let message
+
+        try {
+          message = typeof res.body === 'string' ? JSON.parse(res.body).message : res.body.message
+        } catch {
+          // Not a csrf error
         }
-        const token = res.headers['x-csrf-token']
-        if (token) {
-          opt.headers['X-CSRF-TOKEN'] = token
-          opt.jar = jar
-          args.depth = depth + 1
-          return exports.func(args)
-        } else {
-          throw new Error('Could not refresh X-CSRF-TOKEN')
+
+        if (message === 'XSRF Token Validation Failed' || message === 'Token Validation Failed') {
+          depth++
+
+          if (depth >= 3) {
+            throw new Error('Tried ' + depth + ' times and could not refresh XCSRF token successfully')
+          }
+
+          const token = res.headers['x-csrf-token']
+
+          if (token) {
+            opt.headers['X-CSRF-TOKEN'] = token
+            opt.jar = jar
+            args.depth = depth + 1
+            return exports.func(args)
+          } else {
+            throw new Error('Could not refresh X-CSRF-TOKEN')
+          }
         }
       } else {
         if (depth > 0) {

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -88,7 +88,7 @@ exports.func = function (args) {
         try {
           message = typeof res.body === 'string' ? JSON.parse(res.body).message : res.body.message
         } catch {
-          // Not a csrf error
+          // Roblox didn't send back a properly formed json object
         }
 
         if (message === 'XSRF Token Validation Failed' || message === 'Token Validation Failed') {


### PR DESCRIPTION
It never actually worked earlier, as `.statusMessage` was never written to by noblox or request, so it retained the default forbidden text and noblox would not store the newly received token.