### PR TITLE
Run the linting action on pull requests

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,6 +1,11 @@
 name: Test & Publish
 
 on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
   push:
     branches:
       - master

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -2,6 +2,8 @@ name: Test & Publish
 
 on:
   pull_request:
+    branches:
+      - master
     types:
       - opened
       - synchronize

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - master
-    types:
-      - opened
-      - synchronize
 
   push:
     branches:

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -32,6 +32,7 @@ jobs:
 
   publish-npm:
     needs: test
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code with ADMIN_TOKEN


### PR DESCRIPTION
Lint check currently does not run on pull requests (until merged), it would be easier than having to remember to check manually each time.

auto should not be affected as it only publishes with a release label