### PR TITLE
Fix getCurrentUser redirect error for localized languages

### DIFF
--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -20,35 +20,34 @@ exports.optional = ['jar']
 
 function publishToTopic (universeId, topic, data, jar) {
   return new Promise((resolve, reject) => {
-
     const httpOpt = {
       url: `//apis.roblox.com/messaging-service/v1/universes/${universeId}/topics/${topic}`,
-        options: {
-          json: true,
-          resolveWithFullResponse: true,
-          jar,
-          method: 'POST',
-          body: { message: JSON.stringify(data) },
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }
-    }
-
-  return http(httpOpt)
-    .then(function (res) {
-      if (res.statusCode === 200) {
-        resolve(true)
-      } else {
-        if (typeof(res.body) === "string") {
-          reject(new Error(`[${res.statusCode}] ${res.statusMessage} ${res.body}`))
-        } else {
-          const data = Object.assign(res.body)
-          reject(new Error(`[${res.statusCode}] ${data.Error} ${data.Message}`))
+      options: {
+        json: true,
+        resolveWithFullResponse: true,
+        jar,
+        method: 'POST',
+        body: { message: JSON.stringify(data) },
+        headers: {
+          'Content-Type': 'application/json'
         }
       }
-    })
-    .catch(reject)
+    }
+
+    return http(httpOpt)
+      .then(function (res) {
+        if (res.statusCode === 200) {
+          resolve(true)
+        } else {
+          if (typeof (res.body) === 'string') {
+            reject(new Error(`[${res.statusCode}] ${res.statusMessage} ${res.body}`))
+          } else {
+            const data = Object.assign(res.body)
+            reject(new Error(`[${res.statusCode}] ${data.Error} ${data.Message}`))
+          }
+        }
+      })
+      .catch(reject)
   })
 }
 

--- a/lib/util/getCurrentUser.js
+++ b/lib/util/getCurrentUser.js
@@ -25,7 +25,7 @@ exports.func = async function (args) {
     options: {
       resolveWithFullResponse: true,
       method: 'GET',
-      followRedirect: false,
+      followRedirect: true,
       jar
     }
   }


### PR DESCRIPTION
Accounts that do not use English as their language have the `mobileapi/userinfo` endpoint redirected to a localized path, i.e. `https://www.roblox.com/fr/mobileapi/userinfo`; this causes a HTTP 302 response code and thus throw an error for invalid cookie.

This change allows the redirect, fixing the `setCookie` and `getCurrentUser` without introducing a breaking change.

![image](https://github.com/noblox/noblox.js/assets/34300238/1e5f066b-7f5d-4e29-8d9d-165d432e5911)

--

This change also fixes the linting errors for [`publishToTopic.js`](https://github.com/noblox/noblox.js/assets/34300238/987f929c-d5f3-424f-9620-69d36bf0e42a)
