### PR TITLE
Handle itemconfiguration error codes 37 and 40

### DIFF
--- a/lib/develop/configureItem.js
+++ b/lib/develop/configureItem.js
@@ -113,6 +113,65 @@ function configureRobux (args) {
         } else if (json.errors[0].code === 20) { // "Cannot set the associated asset type to remove-from-release" - caused by copyable asset using sellForRobux: 0
           // Continue and ignore the error as the intended outcome makes the asset private; set sellForRobux from 0 to false
           return configure(args.jar, args.token, args.id, args.name, args.description, args.enableComments, args.sellForRobux, args.genreSelection, !!args.sellForRobux)
+        } else if (json.errors[0].code === 37) { // "AssetIsLimited" - Use the newer endpoint to update price and sale status
+          return http({
+            url: '//catalog.roblox.com/v1/catalog/items/details',
+            options: {
+              method: 'POST',
+              jar: args.jar,
+              json: {
+                items: [
+                  {
+                    id: args.id,
+                    itemType: 1
+                  }
+                ]
+              },
+              resolveWithFullResponse: true
+            }
+          }).then((response) => {
+            if (!response.ok) throw new Error(response.body)
+
+            const { collectibleItemId, price } = JSON.parse(response.body)
+
+            if (!collectibleItemId) throw new Error(`The publishing fee for asset ${args.id} has not been paid, you must do this in order to change or set the price.`)
+
+            return http({
+              url: `//itemconfiguration.roblox.com/v1/collectibles/${collectibleItemId}`,
+              options: {
+                method: 'PATCH',
+                jar: args.jar,
+                headers: {
+                  'X-CSRF-Token': args.token
+                },
+                json: {
+                  isFree: false,
+                  priceInRobux: args.sellForRobux || price,
+                  priceOffset: 0,
+                  quantityLimitPerUser: 0,
+                  resaleRestriction: 2,
+                  saleLocationConfiguration: {
+                    places: [],
+                    saleLocationType: 1
+                  },
+                  saleStatus: args.sellForRobux > 0 ? 0 : 1
+                },
+                resolveWithFullResponse: true
+              }
+            }).then((response) => {
+              if (!response.ok) throw new Error(response.body)
+
+              return {
+                name: args.name,
+                assetId: args.id,
+                description: args.description,
+                price: args.sellForRobux,
+                isCopyingAllowed: null
+              }
+            })
+          })
+        } else if (json.errors[0].code === 40) { // "Use collecibles publishing endpoint." - Publishing fee has not been paid for this asset
+          throw new Error(`The publishing fee for asset ${args.id} has not been paid, you must pay the fee before setting or updating the price.`)
         }
         throw new Error(`An unknown error occurred: [${json.errors[0].code}] ${json.errors[0].message}`)
       }


### PR DESCRIPTION
This resolves #836 and also covers an additional error code I came across when testing.

At some point (preferably when the majority of assets have moved to the new workflow) I'll change this again to make it new-endpoint-first.