### PR TITLE
Fix getPlayerInfo again

### DIFF
--- a/lib/friends/getFollowerCount.js
+++ b/lib/friends/getFollowerCount.js
@@ -16,9 +16,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//friends.roblox.com/v1/users/${userId}/followers/count`,
+    url: `//friends.roblox.com/v1/users/${args.userId}/followers/count`,
     options: {
       json: true,
       method: 'GET',

--- a/lib/friends/getFollowerCount.js
+++ b/lib/friends/getFollowerCount.js
@@ -30,7 +30,7 @@ exports.func = function (userId) {
     if (res.statusCode === 200) { return res.body.count }
 
     throw new Error(
-      `Failed to retrieve follower count: (${res.statusCode}) ${res.body}`
+      `Failed to retrieve follower count: (${res.statusCode}) ${JSON.stringify(res.body)}`
     )
   })
 }

--- a/lib/friends/getFollowingCount.js
+++ b/lib/friends/getFollowingCount.js
@@ -30,7 +30,7 @@ exports.func = function (userId) {
     if (res.statusCode === 200) { return res.body.count }
 
     throw new Error(
-      `Failed to retrieve following count: (${res.statusCode}) ${res.body}`
+      `Failed to retrieve following count: (${res.statusCode}) ${JSON.stringify(res.body)}`
     )
   })
 }

--- a/lib/friends/getFollowingCount.js
+++ b/lib/friends/getFollowingCount.js
@@ -16,9 +16,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//friends.roblox.com/v1/users/${userId}/followings/count`,
+    url: `//friends.roblox.com/v1/users/${args.userId}/followings/count`,
     options: {
       json: true,
       method: 'GET',

--- a/lib/friends/getFriendCount.js
+++ b/lib/friends/getFriendCount.js
@@ -30,7 +30,7 @@ exports.func = function (userId) {
     if (res.statusCode === 200) { return res.body.count }
 
     throw new Error(
-      `Failed to retrieve friend count: (${res.statusCode}) ${res.body}`
+      `Failed to retrieve friend count: (${res.statusCode}) ${JSON.stringify(res.body)}`
     )
   })
 }

--- a/lib/friends/getFriendCount.js
+++ b/lib/friends/getFriendCount.js
@@ -16,9 +16,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//friends.roblox.com/v1/users/${userId}/friends/count`,
+    url: `//friends.roblox.com/v1/users/${args.userId}/friends/count`,
     options: {
       json: true,
       method: 'GET',

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -35,8 +35,7 @@ function getPlayerInfo (userId) {
 
     Promise.all(requests).then((promiseResponses) => {
       const responses = promiseResponses.map(response => response.value)
-      const usersResponse = responses[0]
-      const userBody = usersResponse ? usersResponse.body : {}
+      const userBody = responses[0]
       const failedResponse = promiseResponses.find(presponse => presponse.status === 'rejected') || responses.find(response => !response || (!(response instanceof Array) && (response.statusCode !== 200 || !response.body)))
 
       if (userBody.isBanned) {

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -1,4 +1,5 @@
 // Includes
+const settings = require('../../settings.json')
 const getFollowingCount = require('../friends/getFollowingCount.js').func
 const getFollowerCount = require('../friends/getFollowerCount.js').func
 const getFriendCount = require('../friends/getFriendCount.js').func
@@ -62,8 +63,8 @@ function getPlayerInfo (userId) {
           .join('\n')
 
         if (
-          failureReason.toLowerCase().includes('too many requests') ||
-          failureReason.toLowerCase().includes('(429') &&
+          (failureReason.toLowerCase().includes('too many requests') ||
+            failureReason.toLowerCase().includes('(429')) &&
           settings.show_deprecation_warnings
         ) {
           console.warn()

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -22,10 +22,10 @@ exports.required = ['userId']
 function getPlayerInfo (userId) {
   return new Promise((resolve, reject) => {
     const requests = [
-      getUserInfo(userId),
-      getFriendCount(userId),
-      getFollowingCount(userId),
-      getFollowerCount(userId),
+      getUserInfo({ userId }),
+      getFriendCount({ userId }),
+      getFollowingCount({ userId }),
+      getFollowerCount({ userId }),
     ].map(promise => promise.then(
       val => ({ status: 'fulfilled', value: val }),
       rej => ({ status: 'rejected', reason: rej })

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -36,7 +36,7 @@ function getPlayerInfo (userId) {
     Promise.all(requests).then((promiseResponses) => {
       const responses = promiseResponses.map(response => response.value)
       const userBody = responses[0]
-      const failedResponse = promiseResponses.find(presponse => presponse.status === 'rejected') || responses.find(response => !response || (!(response instanceof Array) && (response.statusCode !== 200 || !response.body)))
+      const failedResponse = promiseResponses.find(presponse => presponse.status === 'rejected') || responses.find(response => !response?.body || response.statusCode !== 200)
 
       if (userBody.isBanned) {
         const joinDate = new Date(userBody.created)

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -3,7 +3,6 @@ const getFollowingCount = require('../friends/getFollowingCount.js').func
 const getFollowerCount = require('../friends/getFollowerCount.js').func
 const getFriendCount = require('../friends/getFriendCount.js').func
 const getUserInfo = require('../users/getUserInfo.js').func
-const getUsernameHistory = require('../users/getUsernameHistory.js').func
 
 // Args
 exports.required = ['userId']
@@ -27,7 +26,6 @@ function getPlayerInfo (userId) {
       getFriendCount(userId),
       getFollowingCount(userId),
       getFollowerCount(userId),
-      getUsernameHistory({ userId })
     ].map(promise => promise.then(
       val => ({ status: 'fulfilled', value: val }),
       rej => ({ status: 'rejected', reason: rej })
@@ -56,7 +54,6 @@ function getPlayerInfo (userId) {
         reject(new Error(failedResponses.map(r => r.reason).join('\n')))
       } else {
         const responseBodies = responses.map(res => res.body ?? res)
-        const oldNames = responses[4].map(nameObject => nameObject.name) || []
         const friendCount = responseBodies[1]
         const followerCount = responseBodies[3]
         const followingCount = responseBodies[2]
@@ -78,7 +75,6 @@ function getPlayerInfo (userId) {
           friendCount,
           followerCount,
           followingCount,
-          oldNames,
           isBanned
         })
       }

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -25,7 +25,7 @@ function getPlayerInfo (userId) {
       getUserInfo({ userId }),
       getFriendCount({ userId }),
       getFollowingCount({ userId }),
-      getFollowerCount({ userId }),
+      getFollowerCount({ userId })
     ].map(promise => promise.then(
       val => ({ status: 'fulfilled', value: val }),
       rej => ({ status: 'rejected', reason: rej })

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -14,9 +14,10 @@ exports.required = ['userId']
  * @alias getPlayerInfo
  * @param { number } userId - The id of the user.
  * @returns {Promise<PlayerInfo>}
+ * @deprecated `getPlayerInfo()` is deprecated; see `getUserInfo()`, `getFollowerCount()`, `getFollowingCount()`, `getFriendCount()`, `getUsernameHistory()`, `getUserFunds()`, `getPlayerThumbnail()` instead - high rate limits on endpoints such as username history and follower count have made this aggregate function not suitable for most users
  * @example const noblox = require("noblox.js")
  * let information = await noblox.getPlayerInfo({userId: 123456})
-**/
+ **/
 
 // Define
 function getPlayerInfo (userId) {
@@ -24,17 +25,22 @@ function getPlayerInfo (userId) {
     const requests = [
       getUserInfo({ userId }),
       getFriendCount({ userId }),
+
       getFollowingCount({ userId }),
       getFollowerCount({ userId })
-    ].map(promise => promise.then(
-      val => ({ status: 'fulfilled', value: val }),
-      rej => ({ status: 'rejected', reason: rej })
-    ))
+    ].map((promise) =>
+      promise.then(
+        (val) => ({ status: 'fulfilled', value: val }),
+        (rej) => ({ status: 'rejected', reason: rej })
+      )
+    )
 
     Promise.all(requests).then((promiseResponses) => {
-      const responses = promiseResponses.map(response => response.value)
+      const responses = promiseResponses.map((response) => response.value)
       const userBody = responses[0]
-      const failedResponses = promiseResponses.filter(presponse => presponse.status === 'rejected')
+      const failedResponses = promiseResponses.filter(
+        (presponse) => presponse.status === 'rejected'
+      )
 
       if (userBody?.isBanned) {
         const joinDate = new Date(userBody.created)
@@ -51,9 +57,39 @@ function getPlayerInfo (userId) {
           displayName
         })
       } else if (failedResponses.length) {
-        reject(new Error(failedResponses.map(r => r.reason).join('\n')))
+        const failureReason = failedResponses
+          .map((response) => response.reason)
+          .join('\n')
+
+        if (
+          failureReason.toLowerCase().includes('too many requests') ||
+          failureReason.toLowerCase().includes('(429') &&
+          settings.show_deprecation_warnings
+        ) {
+          console.warn()
+          console.warn(
+            '=============================================================================================================================================================================================='
+          )
+          console.warn(
+            'DEPRECATION WARNING: getPlayerInfo is an aggregate of multiple endpoints, rate limit changes have made this method unsuitable for many people, please use the individualized endpoints instead'
+          )
+          console.warn(
+            ' see getUserInfo(), getFollowerCount(), getFollowingCount(), getFriendCount(), getUsernameHistory(), getUserFunds(), getPlayerThumbnail()'
+          )
+          console.warn()
+          console.warn(
+            '> Opt out of these warnings using noblox.setOptions({ show_deprecation_warnings: false })'
+          )
+          console.warn(
+            '=============================================================================================================================================================================================='
+          )
+          console.warn()
+        }
+
+        const error = failedResponses.map((r) => r.reason).join('\n')
+        reject(new Error(error))
       } else {
-        const responseBodies = responses.map(res => res.body ?? res)
+        const responseBodies = responses.map((res) => res.body ?? res)
         const friendCount = responseBodies[1]
         const followerCount = responseBodies[3]
         const followingCount = responseBodies[2]
@@ -64,7 +100,11 @@ function getPlayerInfo (userId) {
         const displayName = userBody.displayName
 
         const currentTime = new Date()
-        const age = Math.round(Math.abs((joinDate.getTime() - currentTime.getTime()) / (24 * 60 * 60 * 1000)))
+        const age = Math.round(
+          Math.abs(
+            (joinDate.getTime() - currentTime.getTime()) / (24 * 60 * 60 * 1000)
+          )
+        )
 
         resolve({
           username,

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -36,7 +36,7 @@ function getPlayerInfo (userId) {
     Promise.all(requests).then((promiseResponses) => {
       const responses = promiseResponses.map(response => response.value)
       const userBody = responses[0]
-      const failedResponse = promiseResponses.find(presponse => presponse.status === 'rejected') || responses.find(response => !response?.body || response.statusCode !== 200)
+      const failedResponses = promiseResponses.filter(presponse => presponse.status === 'rejected')
 
       if (userBody.isBanned) {
         const joinDate = new Date(userBody.created)
@@ -52,8 +52,8 @@ function getPlayerInfo (userId) {
           isBanned,
           displayName
         })
-      } else if (failedResponse) {
-        reject(new Error('User does not exist.'))
+      } else if (failedResponses) {
+        reject(new Error(failedResponses.map(r => r.reason).join('\n')))
       } else {
         const responseBodies = responses.map(res => res.body ?? res)
         const oldNames = responses[4].map(nameObject => nameObject.name) || []

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -38,7 +38,7 @@ function getPlayerInfo (userId) {
       const userBody = responses[0]
       const failedResponses = promiseResponses.filter(presponse => presponse.status === 'rejected')
 
-      if (userBody.isBanned) {
+      if (userBody?.isBanned) {
         const joinDate = new Date(userBody.created)
         const blurb = userBody.description
         const isBanned = userBody.isBanned

--- a/lib/users/getPlayerInfo.js
+++ b/lib/users/getPlayerInfo.js
@@ -50,7 +50,7 @@ function getPlayerInfo (userId) {
           isBanned,
           displayName
         })
-      } else if (failedResponses) {
+      } else if (failedResponses.length) {
         reject(new Error(failedResponses.map(r => r.reason).join('\n')))
       } else {
         const responseBodies = responses.map(res => res.body ?? res)

--- a/lib/users/getUserInfo.js
+++ b/lib/users/getUserInfo.js
@@ -14,9 +14,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//users.roblox.com/v1/users/${userId}`,
+    url: `//users.roblox.com/v1/users/${args.userId}`,
     options: {
       json: true,
       method: 'GET',

--- a/lib/users/getUserInfo.js
+++ b/lib/users/getUserInfo.js
@@ -25,7 +25,7 @@ exports.func = function (args) {
   }
 
   return http(httpOpt).then(function (res) {
-    if (res.statusCode !== 200) { throw new Error(`Failed to fetch user information: ${res.body.errors?.join(', ')}`) }
+    if (res.statusCode !== 200) { throw new Error(`Failed to fetch user information: ${res.body?.errors?.at(0)?.message}`) }
 
     res.body.created = new Date(res.body.created)
 

--- a/test/users.test.js
+++ b/test/users.test.js
@@ -53,7 +53,6 @@ describe('Users Methods', () => {
         friendCount: expect.any(Number),
         followerCount: expect.any(Number),
         followingCount: expect.any(Number),
-        oldNames: expect.any(Array),
         isBanned: expect.any(Boolean),
         displayName: expect.any(String)
       })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1145,7 +1145,6 @@ declare module "noblox.js" {
         friendCount?: number;
         followerCount?: number;
         followingCount?: number;
-        oldNames?: string[];
         isBanned: boolean;
     }
 

--- a/typings/jsDocs.ts
+++ b/typings/jsDocs.ts
@@ -1579,7 +1579,6 @@ type PlayerInfo = {
     friendCount?: number;
     followerCount?: number;
     followingCount?: number;
-    oldNames?: Array<string>;
     isBanned: boolean;
 }
 


### PR DESCRIPTION
There are three issues which this solves

- The returned response/value object was never an array to begin with and that finally stopped working at some point that I can't figure out (which is now made moot by the fact that we no longer return response objects since #840)
- We were accessing the `.body` property on the body itself since that change and I forgot to change that beforehand.
- We would throw `User does not exist` regardless of what the true error was, now the error(s) is actually logged.

EDIT: Also drops `getUsernameHistory` so people don't get ratelimited all the time.