### PR TITLE
Migrate methods to RobloxAPIError class

### DIFF
--- a/lib/accountinformation/getUserSocialLinks.js
+++ b/lib/accountinformation/getUserSocialLinks.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -25,14 +26,11 @@ function getUserSocialLinks (userId, jar) {
       resolveWithFullResponse: true
     }
   })
-    .then(({ statusCode, body }) => {
-      const { errors } = JSON.parse(body)
-      if (statusCode === 200) {
-        return JSON.parse(body)
-      } else if (statusCode === 400) {
-        throw new Error(`${errors[0].message} | userId: ${userId}`)
+    .then((res) => {
+      if (res.statusCode === 200) {
+        return JSON.parse(res.body)
       } else {
-        throw new Error(`An unknown error occurred with getUserSocialLinks() | [${statusCode}] userId: ${userId}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/accountsettings/block.js
+++ b/lib/accountsettings/block.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -37,13 +38,7 @@ function block (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/accountsettings/unblock.js
+++ b/lib/accountsettings/unblock.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -37,13 +38,7 @@ function unblock (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/asset/deleteFromInventory.js
+++ b/lib/asset/deleteFromInventory.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['assetId']
@@ -28,30 +29,17 @@ function deleteFromInventory (jar, assetId, xcsrf) {
         resolveWithFullResponse: true,
         jar,
         headers: {
-          'X-CSRF-TOKEN': xcsrf,
-          'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
+          'X-CSRF-TOKEN': xcsrf
         }
       }
     }
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = typeof res.body === 'string' ? JSON.parse(res.body) : res.body
-        // Roblox likes to error here with 200 status codes too with inconsistency
         if (res.statusCode === 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && !responseData.isValid) {
-            error = responseData.error
-            reject(new Error(error))
-          } else if (responseData && responseData.isValid) {
-            resolve()
-          }
+          resolve()
         } else {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/asset/getGamePassProductInfo.js
+++ b/lib/asset/getGamePassProductInfo.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['gamepass']
@@ -33,9 +34,7 @@ function getGamePassProductInfo (gamepass) {
         if (res.statusCode === 200) {
           resolve(data)
         } else {
-          const errors = data.errors.map((e) => e.message)
-
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/asset/getProductInfo.js
+++ b/lib/asset/getProductInfo.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['asset']
@@ -30,18 +31,7 @@ function getProductInfo (asset) {
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body))
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          const body = isAnObject(res.body) ? JSON.parse(res.body) : {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} ${res.body}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/avatar/avatarRules.js
+++ b/lib/avatar/avatarRules.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['option', 'jar']
 
@@ -32,7 +33,7 @@ exports.func = (args) => {
 
       return result
     } else {
-      throw new Error('Error fetching avatar rules')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/currentlyWearing.js
+++ b/lib/avatar/currentlyWearing.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util')
 
 exports.required = ['userId']
 
@@ -26,7 +27,7 @@ exports.func = (args) => {
     if (res.statusCode === 200) {
       return JSON.parse(res.body)
     } else {
-      throw new Error('User does not exist')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/getAvatar.js
+++ b/lib/avatar/getAvatar.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['userId']
 
@@ -24,7 +25,7 @@ const getAvatar = (userId) => {
     if (res.statusCode === 200) {
       return JSON.parse(res.body)
     } else {
-      throw new Error('User does not exist')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/getCurrentAvatar.js
+++ b/lib/avatar/getCurrentAvatar.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['option', 'jar']
 
@@ -28,7 +29,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       const json = JSON.parse(res.body)
       return (option ? json[option] : json)

--- a/lib/avatar/getRecentItems.js
+++ b/lib/avatar/getRecentItems.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['listType', 'jar']
 
@@ -26,12 +27,10 @@ exports.func = (args) => {
       resolveWithFullResponse: true
     }
   }).then((res) => {
-    if (res.statusCode === 401) {
-      throw new Error('You are not logged in')
-    } else if (res.statusCode === 400) {
-      throw new Error('Invalid list type')
-    } else {
+    if (res.statusCode === 200) {
       return JSON.parse(res.body)
+    } else {
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/outfitDetails.js
+++ b/lib/avatar/outfitDetails.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['outfitId']
 
@@ -26,7 +27,7 @@ exports.func = (args) => {
     if (res.statusCode === 200) {
       return JSON.parse(res.body)
     } else {
-      throw new Error('Outfit does not exist')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/outfits.js
+++ b/lib/avatar/outfits.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['userId']
 exports.optional = ['page', 'itemsPerPage']
@@ -31,7 +32,7 @@ exports.func = (args) => {
     if (res.statusCode === 200) {
       return JSON.parse(res.body)
     } else {
-      throw new Error('User does not exist')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/redrawAvatar.js
+++ b/lib/avatar/redrawAvatar.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['jar']
 
@@ -30,10 +31,8 @@ function redrawAvatar (jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         resolve()
-      } else if (res.statusCode === 429) {
-        reject(new Error('Redraw avatar floodchecked'))
       } else {
-        reject(new Error('Redraw avatar failed'))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/avatar/removeAssetId.js
+++ b/lib/avatar/removeAssetId.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['assetId']
 exports.optional = ['jar']
@@ -32,13 +33,8 @@ function removeAssetId (assetId, jar, xcsrf) {
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve()
         }

--- a/lib/avatar/setAvatarBodyColors.js
+++ b/lib/avatar/setAvatarBodyColors.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['headColorId', 'torsoColorId', 'rightArmColorId', 'leftArmColorId', 'rightLegColorId', 'leftLegColorId']
 exports.optional = ['jar']
@@ -43,10 +44,10 @@ const nextFunction = (jar, token, headColorId, torsoColorId, rightArmColorId, le
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.success) {
-        throw new Error(res.body)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Set body colors failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/setAvatarScales.js
+++ b/lib/avatar/setAvatarScales.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['height', 'width', 'head']
 exports.optional = ['depth', 'proportion', 'bodyType', 'jar']
@@ -43,10 +44,10 @@ const nextFunction = (jar, token, height, width, head, depth, proportion, bodyTy
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.success) {
-        throw new Error(res.body)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Set avatar scale failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/setPlayerAvatarType.js
+++ b/lib/avatar/setPlayerAvatarType.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['avatarType']
 exports.optional = ['jar']
@@ -33,10 +34,10 @@ const nextFunction = (jar, token, avatarType) => {
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.success) {
-        throw new Error(res.body)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Set avatar type failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/setWearingAssets.js
+++ b/lib/avatar/setWearingAssets.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['assetIds']
 exports.optional = ['jar']
@@ -33,10 +34,10 @@ const nextFunction = (jar, token, assetIds) => {
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.success) {
-        throw new Error('Invalid assets: ' + res.body.invalidAssetIds.join(', '))
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Wear assets failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/avatar/wearAssetId.js
+++ b/lib/avatar/wearAssetId.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['assetId']
 exports.optional = ['jar']
@@ -32,13 +33,8 @@ function wearAssetId (assetId, jar, xcsrf) {
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve()
         }

--- a/lib/badges/getAwardedTimestamps.js
+++ b/lib/badges/getAwardedTimestamps.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http').func
+const RobloxAPIError = require('../util/apiError')
 
 // Args
 exports.required = ['userId', 'badgeId']
@@ -31,11 +32,7 @@ const getAwardedTimestamps = (userId, badgeId) => {
       .then(function (res) {
         const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(responseData)
         }

--- a/lib/badges/getBadgeInfo.js
+++ b/lib/badges/getBadgeInfo.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http').func
+const RobloxAPIError = require('../util/apiError')
 
 // Args
 exports.required = ['badgeId']
@@ -30,7 +31,7 @@ const badgeInfo = async (id) => {
       json.updated = new Date(json.updated)
       return json
     } else {
-      throw new Error('Badge is invalid or does not exist.')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/badges/getGameBadges.js
+++ b/lib/badges/getGameBadges.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http').func
+const RobloxAPIError = require('../util/apiError')
 
 // Args
 exports.required = ['universeId']
@@ -37,7 +38,7 @@ const gameBadges = async (id, limit, cursor, order) => {
       })
       return json.data
     } else {
-      throw new Error('The game is invalid or does not exist.')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/badges/updateBadgeInfo.js
+++ b/lib/badges/updateBadgeInfo.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['badgeId']
@@ -42,14 +43,8 @@ const updateInfo = (id, name, desc, enabled, xcrsf, jar) => {
   }).then(res => {
     if (res.statusCode === 200) {
       return JSON.parse(res.body)
-    } else if (res.statusCode === 400) {
-      throw new Error('Text moderated.')
-    } else if (res.statusCode === 401) {
-      throw new Error('Authorization has been denied for this request.')
-    } else if (res.statusCode === 403) {
-      throw new Error('Token Validation failed or you do not have permission to manage this badge.')
-    } else if (res.statusCode === 404) {
-      throw new Error('Badge is invalid or does not exist.')
+    } else {
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/chat/addUsersToConversation.js
+++ b/lib/chat/addUsersToConversation.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId', 'userIds']
 exports.optional = ['jar']
@@ -37,16 +38,12 @@ function addUsersToConversation (conversationId, userIds, jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         if (!res.body.resultType === 'Success') {
-          reject(new Error(res.body.statusMessage))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(res.body)
         }
       } else {
-        let error = 'An unknown error has occurred.'
-        if (res.body && res.body.errors) {
-          error = res.body.errors.map((e) => e.message).join('\n')
-        }
-        reject(new Error(error))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/chat/chatSettings.js
+++ b/lib/chat/chatSettings.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['jar']
 
@@ -25,7 +26,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/getChatMessages.js
+++ b/lib/chat/getChatMessages.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId']
 exports.optional = ['pageSize', 'exclusiveStartMessageId', 'jar']
@@ -32,7 +33,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/getConversations.js
+++ b/lib/chat/getConversations.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationIds']
 exports.optional = ['jar']
@@ -28,13 +29,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      const body = JSON.parse(res.body) || {}
-      if (body.errors && body.errors.length > 0) {
-        const errors = body.errors.map((e) => {
-          return e.message
-        })
-        throw new Error(`${res.statusCode} ${errors.join(', ')}`)
-      }
+      throw new RobloxAPIError(res)
     } else {
       let response = JSON.parse(res.body)
 

--- a/lib/chat/getRolloutSettings.js
+++ b/lib/chat/getRolloutSettings.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['featureNames', 'jar']
 
@@ -27,7 +28,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/getUnreadConversationCount.js
+++ b/lib/chat/getUnreadConversationCount.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['jar']
 
@@ -25,7 +26,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/getUnreadMessages.js
+++ b/lib/chat/getUnreadMessages.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationIds']
 exports.optional = ['pageSize', 'jar']
@@ -30,7 +31,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/getUserConversations.js
+++ b/lib/chat/getUserConversations.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.optional = ['pageNumber', 'pageSize', 'jar']
 
@@ -29,7 +30,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/markChatAsRead.js
+++ b/lib/chat/markChatAsRead.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId', 'endMessageId']
 exports.optional = ['jar']
@@ -35,10 +36,10 @@ const nextFunction = (jar, token, conversationId, endMessageId) => {
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.resultType === 'Success') {
-        throw new Error(res.body.statusMessage)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Mark as read failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/chat/markChatAsSeen.js
+++ b/lib/chat/markChatAsSeen.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationIds']
 exports.optional = ['jar']
@@ -33,10 +34,10 @@ const nextFunction = (jar, token, conversationIds) => {
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.resultType === 'Success') {
-        throw new Error(res.body.statusMessage)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Mark as seen failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/chat/multiGetLatestMessages.js
+++ b/lib/chat/multiGetLatestMessages.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationIds']
 exports.optional = ['pageSize', 'jar']
@@ -29,7 +30,7 @@ exports.func = (args) => {
     }
   }).then((res) => {
     if (res.statusCode !== 200) {
-      throw new Error('You are not logged in')
+      throw new RobloxAPIError(res)
     } else {
       return JSON.parse(res.body)
     }

--- a/lib/chat/removeFromGroupConversation.js
+++ b/lib/chat/removeFromGroupConversation.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId', 'userId']
 exports.optional = ['jar']
@@ -38,16 +39,12 @@ function removeFromGroupConversation (conversationId, userId, jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         if (!res.body.resultType === 'Success') {
-          reject(new Error(res.body.statusMessage))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(res.body)
         }
       } else {
-        let error = 'An unknown error has occurred.'
-        if (res.body && res.body.errors) {
-          error = res.body.errors.map((e) => e.message).join('\n')
-        }
-        reject(new Error(error))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/chat/renameGroupConversation.js
+++ b/lib/chat/renameGroupConversation.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId', 'title']
 exports.optional = ['jar']
@@ -37,12 +38,12 @@ function renameGroupConversation (conversationId, newTitle, jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         if (!res.body.resultType === 'Success') {
-          reject(new Error(res.body.statusMessage))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(res.body)
         }
       } else {
-        reject(new Error('Rename group chat failed'))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/chat/sendChatMessage.js
+++ b/lib/chat/sendChatMessage.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId', 'message']
 exports.optional = ['jar']
@@ -37,12 +38,12 @@ function sendChatMessage (conversationId, messageText, jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         if (!res.body.resultType === 'Success') {
-          reject(new Error(res.body.statusMessage))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(res.body)
         }
       } else {
-        throw new Error('Send chat message failed')
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/chat/setChatUserTyping.js
+++ b/lib/chat/setChatUserTyping.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['conversationId', 'isTyping']
 exports.optional = ['jar']
@@ -37,16 +38,12 @@ function setChatUserTyping (conversationId, isTyping, jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         if (!res.body.resultType === 'Success') {
-          reject(new Error(res.body.statusMessage))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(res.body)
         }
       } else {
-        let error = 'An unknown error has occurred.'
-        if (res.body && res.body.errors) {
-          error = res.body.errors.map((e) => e.message).join('\n')
-        }
-        reject(new Error(error))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/chat/start121Conversation.js
+++ b/lib/chat/start121Conversation.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['userId']
 exports.optional = ['jar']
@@ -33,10 +34,10 @@ const nextFunction = (jar, token, userId) => {
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.resultType === 'Success') {
-        throw new Error(res.body.statusMessage)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Start conversation failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/chat/startCloudEditConversation.js
+++ b/lib/chat/startCloudEditConversation.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['placeId']
 exports.optional = ['jar']
@@ -33,10 +34,10 @@ const nextFunction = (jar, token, placeId) => {
   }).then((res) => {
     if (res.statusCode === 200) {
       if (!res.body.resultType === 'Success') {
-        throw new Error(res.body.statusMessage)
+        throw new RobloxAPIError(res)
       }
     } else {
-      throw new Error('Start cloud edit chat failed')
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/chat/startGroupConversation.js
+++ b/lib/chat/startGroupConversation.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['userIds', 'title']
 exports.optional = ['jar']
@@ -38,16 +39,12 @@ function startGroupConversation (userIds, chatTitle, jar, token) {
     return http(httpOpt).then((res) => {
       if (res.statusCode === 200) {
         if (!res.body.resultType === 'Success') {
-          reject(new Error(res.body.statusMessage))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(res.body)
         }
       } else {
-        let error = 'An unknown error has occurred.'
-        if (res.body && res.body.errors) {
-          error = res.body.errors.map((e) => e.message).join('\n')
-        }
-        reject(new Error(error))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/datastores/deleteDatastoreEntry.js
+++ b/lib/datastores/deleteDatastoreEntry.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'datastoreName', 'entryKey']
@@ -43,18 +44,7 @@ function deleteDatastoreEntry (universeId, datastoreName, entryKey, scope = 'glo
         if (res.statusCode === 204) {
           resolve()
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/datastores/getDatastoreEntry.js
+++ b/lib/datastores/getDatastoreEntry.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'datastoreName', 'entryKey']
@@ -75,18 +76,7 @@ function getDatastoreEntry (universeId, datastoreName, entryKey, scope = 'global
             }
           })
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/datastores/getDatastoreEntryVersions.js
+++ b/lib/datastores/getDatastoreEntryVersions.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'datastoreName', 'entryKey']
@@ -60,18 +61,7 @@ function getDatastoreEntryVersions (universeId, datastoreName, entryKey, scope =
 
           resolve(response)
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/datastores/getDatastoreKeys.js
+++ b/lib/datastores/getDatastoreKeys.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'datastoreName']
@@ -50,18 +51,7 @@ function getDatastoreKeys (universeId, datastoreName, scope = 'global', prefix, 
 
           resolve(response)
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/datastores/getDatastores.js
+++ b/lib/datastores/getDatastores.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId']
@@ -49,18 +50,7 @@ function getDatastores (universeId, prefix, limit, cursor, jar) {
 
           resolve(response)
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/datastores/incrementDatastoreEntry.js
+++ b/lib/datastores/incrementDatastoreEntry.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const crypto = require('crypto')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'datastoreName', 'entryKey', 'incrementBy']
@@ -70,18 +71,7 @@ function incrementDatastoreEntry (universeId, datastoreName, entryKey, increment
             }
           })
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/datastores/setDatastoreEntry.js
+++ b/lib/datastores/setDatastoreEntry.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const crypto = require('crypto')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'datastoreName', 'entryKey', 'body']
@@ -67,18 +68,7 @@ function setDatastoreEntry (universeId, datastoreName, entryKey, body, scope = '
 
           resolve(response)
         } else {
-          // Sourced from: https://stackoverflow.com/a/32278428
-          const isAnObject = (val) => !!(val instanceof Array || val instanceof Object)
-
-          let body
-
-          try {
-            body = isAnObject(JSON.parse(res.body)) ? JSON.parse(res.body) : {}
-          } catch (error) {
-            reject(new Error(`${res.statusCode} ${res.statusMessage}`))
-          }
-
-          reject(new Error(`${res.statusCode} ${body.error} ${body.message}`))
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/develop/updateUniverse.js
+++ b/lib/develop/updateUniverse.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'settings']
@@ -33,13 +34,11 @@ function updateUniverse (universeId, settings, jar, token) {
         json: settings,
         resolveWithFullResponse: true
       }
-    }).then(({ statusCode, body }) => {
-      if (statusCode === 200) {
-        resolve(body)
-      } else if (body && body.errors) {
-        reject(new Error(`[${statusCode}] ${body.errors[0].message} | universeId: ${universeId}, settings: ${JSON.stringify(settings)} ${body.errors.field ? ` | ${body.errors.field} is incorrect` : ''}`))
+    }).then((res) => {
+      if (res.statusCode === 200) {
+        resolve(res.body)
       } else {
-        reject(new Error(`An unknown error occurred with updateUniverse() | [${statusCode}] universeId: ${universeId}, settings: ${JSON.stringify(settings)}`))
+        reject(new RobloxAPIError(res))
       }
     }).catch(reject)
   })

--- a/lib/develop/updateUniverseAccess.js
+++ b/lib/develop/updateUniverseAccess.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId', 'isPublic']
@@ -35,13 +36,11 @@ function updateUniverseAccess (universeId, isPublic, jar, token) {
         },
         resolveWithFullResponse: true
       }
-    }).then(({ statusCode, body }) => {
-      if (statusCode === 200) {
+    }).then((res) => {
+      if (res.statusCode === 200) {
         resolve()
-      } else if (body && body.errors) {
-        reject(new Error(`[${statusCode}] ${body.errors[0].message} | universeId: ${universeId}, isPublic: ${isPublic} ${body.errors.field ? ` | ${body.errors.field} is incorrect` : ''}`))
       } else {
-        reject(new Error(`An unknown error occurred with updateUniverseAccess() | [${statusCode}] universeId: ${universeId}, isPublic: ${isPublic}`))
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/economy/getGroupFunds.js
+++ b/lib/economy/getGroupFunds.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -26,14 +27,12 @@ function getGroupFunds (group, jar) {
       resolveWithFullResponse: true
     }
   })
-    .then(({ statusCode, body }) => {
-      const { robux, errors } = JSON.parse(body)
-      if (statusCode === 200) {
+    .then((res) => {
+      const { robux } = JSON.parse(res.body)
+      if (res.statusCode === 200) {
         return robux
-      } else if (statusCode === 400 || statusCode === 403) {
-        throw new Error(`${errors[0].message} | groupId: ${group}`)
       } else {
-        throw new Error(`An unknown error occurred with getGroupFunds() | [${statusCode}] groupId: ${group}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/economy/getGroupRevenueSummary.js
+++ b/lib/economy/getGroupRevenueSummary.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['groupId']
@@ -27,18 +28,11 @@ function getGroupRevenueSummary (group, timeFrame, jar) {
       resolveWithFullResponse: true
     }
   })
-    .then(({ statusCode, body }) => {
-      const { errors } = JSON.parse(body)
-      if (statusCode === 200) {
-        return JSON.parse(body)
-      } else if (statusCode === 400) {
-        throw new Error(`${errors[0].message} | group: ${group}, timeFrame: ${timeFrame}`)
-      } else if (statusCode === 401) {
-        throw new Error(`${errors[0].message} (Are you logged in?) | group: ${group}, timeFrame: ${timeFrame}`)
-      } else if (statusCode === 403) {
-        throw new Error('Insufficient permissions: "Spend group funds" role permissions required')
+    .then((res) => {
+      if (res.statusCode === 200) {
+        return JSON.parse(res.body)
       } else {
-        throw new Error(`An unknown error occurred with getGroupRevenueSummary() | [${statusCode}] group: ${group}, timeFrame: ${timeFrame}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/economy/getResaleData.js
+++ b/lib/economy/getResaleData.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http').func
+const RobloxAPIError = require('../util/apiError')
 
 // Args
 exports.required = ['assetId']
@@ -23,25 +24,18 @@ const getResaleData = async (assetId) => {
     options: {
       resolveWithFullResponse: true
     }
-  }).then(({ body, statusCode }) => {
-    const { errors } = JSON.parse(body)
-    if (statusCode === 200) {
-      try {
-        const resaleData = JSON.parse(body)
-        for (const priceDataPoint of resaleData.priceDataPoints) {
-          priceDataPoint.date = new Date(priceDataPoint.date)
-        }
-        for (const volumeDataPoint of resaleData.volumeDataPoints) {
-          volumeDataPoint.date = new Date(volumeDataPoint.date)
-        }
-        return resaleData
-      } catch (err) {
-        throw new Error(`An unknown error occurred with getResaleData() | [${statusCode}] assetId: ${assetId}`)
+  }).then((res) => {
+    if (res.statusCode === 200) {
+      const resaleData = JSON.parse(res.body)
+      for (const priceDataPoint of resaleData.priceDataPoints) {
+        priceDataPoint.date = new Date(priceDataPoint.date)
       }
-    } else if (statusCode === 400) {
-      throw new Error(`${errors[0].message} | assetId: ${assetId}`)
+      for (const volumeDataPoint of resaleData.volumeDataPoints) {
+        volumeDataPoint.date = new Date(volumeDataPoint.date)
+      }
+      return resaleData
     } else {
-      throw new Error(`An unknown error occurred with getResaleData() | [${statusCode}] assetId: ${assetId}`)
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/economy/getUserFunds.js
+++ b/lib/economy/getUserFunds.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -27,14 +28,12 @@ function getUserFunds (userId, jar) {
       resolveWithFullResponse: true
     }
   })
-    .then(({ statusCode, body }) => {
-      const { robux, errors } = JSON.parse(body)
-      if (statusCode === 200) {
+    .then((res) => {
+      const { robux } = JSON.parse(res.body)
+      if (res.statusCode === 200) {
         return robux
-      } else if (statusCode === 400 || statusCode === 403) {
-        throw new Error(`${errors[0].message} | userId: ${userId}`)
       } else {
-        throw new Error(`An unknown error occurred with getUserFunds() | [${statusCode}] userId: ${userId}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/friends/acceptFriendRequest.js
+++ b/lib/friends/acceptFriendRequest.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -38,13 +39,7 @@ function acceptFriendRequest (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/declineAllFriendRequests.js
+++ b/lib/friends/declineAllFriendRequests.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = []
@@ -36,13 +37,7 @@ function declineAllFriendRequests (jar, token) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/declineFriendRequest.js
+++ b/lib/friends/declineFriendRequest.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -38,13 +39,7 @@ function declineFriendRequest (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/getFollowerCount.js
+++ b/lib/friends/getFollowerCount.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -16,9 +17,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//friends.roblox.com/v1/users/${userId}/followers/count`,
+    url: `//friends.roblox.com/v1/users/${args.userId}/followers/count`,
     options: {
       json: true,
       method: 'GET',
@@ -29,8 +30,6 @@ exports.func = function (userId) {
   return http(httpOpt).then(function (res) {
     if (res.statusCode === 200) { return res.body.count }
 
-    throw new Error(
-      `Failed to retrieve follower count: (${res.statusCode}) ${res.body}`
-    )
+    throw new RobloxAPIError(res)
   })
 }

--- a/lib/friends/getFollowers.js
+++ b/lib/friends/getFollowers.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -40,13 +41,7 @@ function getFollowers (jar, userId, sortOrder, limit, cursor) {
           })
           resolve(response)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/getFollowingCount.js
+++ b/lib/friends/getFollowingCount.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -16,9 +17,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//friends.roblox.com/v1/users/${userId}/followings/count`,
+    url: `//friends.roblox.com/v1/users/${args.userId}/followings/count`,
     options: {
       json: true,
       method: 'GET',
@@ -29,8 +30,6 @@ exports.func = function (userId) {
   return http(httpOpt).then(function (res) {
     if (res.statusCode === 200) { return res.body.count }
 
-    throw new Error(
-      `Failed to retrieve following count: (${res.statusCode}) ${res.body}`
-    )
+    throw new RobloxAPIError(res)
   })
 }

--- a/lib/friends/getFollowings.js
+++ b/lib/friends/getFollowings.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -40,13 +41,7 @@ function getFollowings (jar, userId, sortOrder, limit, cursor) {
           })
           resolve(response)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/getFriendCount.js
+++ b/lib/friends/getFriendCount.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -16,9 +17,9 @@ exports.required = ['userId']
 **/
 
 // Define
-exports.func = function (userId) {
+exports.func = function (args) {
   const httpOpt = {
-    url: `//friends.roblox.com/v1/users/${userId}/friends/count`,
+    url: `//friends.roblox.com/v1/users/${args.userId}/friends/count`,
     options: {
       json: true,
       method: 'GET',
@@ -29,8 +30,6 @@ exports.func = function (userId) {
   return http(httpOpt).then(function (res) {
     if (res.statusCode === 200) { return res.body.count }
 
-    throw new Error(
-      `Failed to retrieve friend count: (${res.statusCode}) ${res.body}`
-    )
+    throw new RobloxAPIError(res)
   })
 }

--- a/lib/friends/getFriendRequests.js
+++ b/lib/friends/getFriendRequests.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = []
@@ -41,13 +42,7 @@ function getFriendsRequests (args) {
           })
           resolve(response)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/getFriends.js
+++ b/lib/friends/getFriends.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 // Args
 exports.required = ['userId']
 exports.optional = ['jar']
@@ -36,13 +37,7 @@ function getFriends (jar, userId) {
           })
           resolve(response)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/removeFriend.js
+++ b/lib/friends/removeFriend.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -37,13 +38,7 @@ function removeFriend (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/sendFriendRequest.js
+++ b/lib/friends/sendFriendRequest.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -38,13 +39,7 @@ function sendFriendRequest (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/friends/unfollow.js
+++ b/lib/friends/unfollow.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -37,13 +38,7 @@ function unfollow (jar, token, userId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/games/addDeveloperProduct.js
+++ b/lib/games/addDeveloperProduct.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['universeId', 'name', 'priceInRobux']
 exports.optional = ['description', 'jar']
@@ -38,8 +39,8 @@ const nextFunction = (jar, token, universeId, name, priceInRobux, description) =
         return json
       }
       throw new Error(json)
-    } catch (err) {
-      throw new Error(res.body)
+    } catch (_) {
+      throw new RobloxAPIError(res)
     }
   })
 }

--- a/lib/games/configureGamePass.js
+++ b/lib/games/configureGamePass.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http').func
 const getGeneralToken = require('../util/getGeneralToken').func
+const RobloxAPIError = require('../util/apiError')
 
 // Args
 exports.required = ['gamePassId', 'name']
@@ -61,12 +62,7 @@ function configureGamePass (gamePassId, name, description, price, icon, jar, tok
           iconChanged: !!icon // Boolean Cast
         })
       } else {
-        const priceComment = (typeof (price) === 'number') ? ` | NOTE: Price has successfully been changed to ${price}R.` : ''
-        if (res.statusCode === 403) {
-          reject(new Error(`You do not have permission to edit this game pass.${priceComment}`))
-        } else {
-          reject(new Error(`An unexpected error occurred with status code ${res.statusCode}.${priceComment}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/games/getDeveloperProducts.js
+++ b/lib/games/getDeveloperProducts.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['placeId']
@@ -30,15 +31,7 @@ function getDeveloperProducts (jar, placeId, page) {
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body))
         } else {
-          const body = res.body || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} An error has occurred ${res.body ? res.body : ''}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/games/getGameRevenue.js
+++ b/lib/games/getGameRevenue.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['placeId', 'type', 'granularity']
 exports.optional = ['jar']
@@ -32,9 +33,7 @@ function getGameRevenue (placeId, type, granularity, jar, token) {
     return http(httpOpt)
       .then(function (res) {
         if (res.statusCode === 200) resolve(JSON.parse(res.body))
-        else if (res.statusCode === 401) reject(new Error('You are not logged in.'))
-        else if (res.statusCode === 403) reject(new Error('You do not have permission to view this game.'))
-        else reject(new Error('An unknown error occurred.'))
+        else reject(new RobloxAPIError(res))
       })
       .catch(function (err) { console.error(err); reject(err) })
   })

--- a/lib/games/getGameSocialLinks.js
+++ b/lib/games/getGameSocialLinks.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId']
@@ -26,16 +27,12 @@ function getGameSocialLinks (universeId, jar) {
       resolveWithFullResponse: true
     }
   })
-    .then(({ statusCode, body }) => {
-      const { errors, data } = JSON.parse(body)
-      if (statusCode === 200 && data) {
+    .then((res) => {
+      const { data } = JSON.parse(res.body)
+      if (res.statusCode === 200) {
         return data
-      } else if (statusCode === 400 || statusCode === 403 || statusCode === 404) {
-        throw new Error(`${errors[0].message} | universeId: ${universeId}`)
-      } else if (statusCode === 401) {
-        throw new Error(`${errors[0].message} (Are you logged in?) | universeId: ${universeId}`)
       } else {
-        throw new Error(`An unknown error occurred with getGameSocialLinks() | [${statusCode}] universeId: ${universeId}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/games/getPlaceInfo.js
+++ b/lib/games/getPlaceInfo.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['placeId']
@@ -31,13 +32,11 @@ function getPlaceInfo (placeIds, jar) {
     }
 
     return http(httpOpt)
-      .then(function ({ statusCode, body }) {
-        if (statusCode === 200) {
-          resolve(body)
-        } else if (body && body.errors) {
-          reject(new Error(`[${statusCode}] ${body.errors[0].message} | placeIds: ${placeIds.join(',')} ${body.errors.field ? ` | ${body.errors.field} is incorrect` : ''}`))
+      .then(function (res) {
+        if (res.statusCode === 200) {
+          resolve(res.body)
         } else {
-          reject(new Error(`An unknown error occurred with getPlaceInfo() | [${statusCode}] placeIds: ${placeIds.join(',')}`))
+          reject(new RobloxAPIError(res))
         }
       }).catch(reject)
   })

--- a/lib/games/getUniverseInfo.js
+++ b/lib/games/getUniverseInfo.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['universeId']
 exports.optional = ['jar']
@@ -29,18 +30,16 @@ function getUniverseInfo (universeIds, jar) {
     }
 
     return http(httpOpt)
-      .then(function ({ statusCode, body }) {
-        if (statusCode === 200) {
-          resolve(body.data.map((universe) => {
+      .then(function (res) {
+        if (res.statusCode === 200) {
+          resolve(res.body.data.map((universe) => {
             universe.created = new Date(universe.created)
             universe.updated = new Date(universe.updated)
 
             return universe
           }))
-        } else if (body && body.errors) {
-          reject(new Error(`[${statusCode}] ${body.errors[0].message} | universeIds: ${universeIds.join(',')} ${body.errors.field ? ` | ${body.errors.field} is incorrect` : ''}`))
         } else {
-          reject(new Error(`An unknown error occurred with getUniverseInfo() | [${statusCode}] universeIds: ${universeIds.join(',')}`))
+          reject(new RobloxAPIError(res))
         }
       }).catch(reject)
   })

--- a/lib/games/publishToTopic.js
+++ b/lib/games/publishToTopic.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['universeId', 'topic', 'data']
 exports.optional = ['jar']
@@ -39,12 +40,7 @@ function publishToTopic (universeId, topic, data, jar) {
         if (res.statusCode === 200) {
           resolve(true)
         } else {
-          if (typeof (res.body) === 'string') {
-            reject(new Error(`[${res.statusCode}] ${res.statusMessage} ${res.body}`))
-          } else {
-            const data = Object.assign(res.body)
-            reject(new Error(`[${res.statusCode}] ${data.Error} ${data.Message}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(reject)

--- a/lib/games/updateDeveloperProduct.js
+++ b/lib/games/updateDeveloperProduct.js
@@ -1,5 +1,6 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['universeId', 'productId', 'priceInRobux']
 exports.optional = ['name', 'description', 'jar']
@@ -37,21 +38,11 @@ function updateDeveloperProduct (universeId, productId, priceInRobux, name, desc
         },
         resolveWithFullResponse: true
       }
-    }).then(({ statusCode, body }) => {
-      if (statusCode === 200) {
-        resolve(body)
-      } else if (body && body.errors) {
-        reject(new Error(`[${statusCode}] ${body.errors[0].message} | universeId: ${universeId}, body: ${JSON.stringify({
-          Name: name,
-          Description: description,
-          PriceInRobux: priceInRobux
-        })}`))
+    }).then((res) => {
+      if (res.statusCode === 200) {
+        resolve(res.body)
       } else {
-        reject(new Error(`An unknown error occurred with updateDeveloperProduct() | [${statusCode}] universeId: ${universeId}, body: ${JSON.stringify({
-          Name: name,
-          Description: description,
-          PriceInRobux: priceInRobux
-        })}`))
+        reject(new RobloxAPIError(res))
       }
     }).catch(reject)
   })

--- a/lib/groups/deleteWallPost.js
+++ b/lib/groups/deleteWallPost.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', ['postId', 'post']]
@@ -38,13 +39,7 @@ function deleteWallPost (jar, token, group, postId) {
         if (res.statusCode === 200) {
           resolve()
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       }).catch(error => reject(error))
   })

--- a/lib/groups/deleteWallPostsByUser.js
+++ b/lib/groups/deleteWallPostsByUser.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'userId']
@@ -35,13 +36,8 @@ function deleteWallPostsByUser (group, userId, jar, xcsrf) {
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve()
         }

--- a/lib/groups/exile.js
+++ b/lib/groups/exile.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'target']
@@ -35,13 +36,8 @@ function exileUser (group, target, jar, xcsrf) {
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve()
         }

--- a/lib/groups/getAuditLog.js
+++ b/lib/groups/getAuditLog.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['group']
 exports.optional = ['actionType', 'userId', 'sortOrder', 'limit', 'cursor', 'jar']
@@ -36,11 +37,7 @@ function getAuditLog (group, actionType, userId, sortOrder, limit, cursor, jar) 
       .then(function (res) {
         const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           responseData.data = responseData.data.map((entry) => {
             // We need to set milliseconds to 0 because Roblox does this fascinating thing

--- a/lib/groups/getGroup.js
+++ b/lib/groups/getGroup.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['groupId']
@@ -38,15 +39,7 @@ function getGroup (groupId) {
 
           resolve(body)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} ${res.body}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       }).catch(error => reject(error))
   })

--- a/lib/groups/getGroupSocialLinks.js
+++ b/lib/groups/getGroupSocialLinks.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 
+const RobloxAPIError = require('../util/apiError.js')
 // Args
 exports.required = ['groupId']
 exports.optional = ['jar']
@@ -25,16 +26,12 @@ function getGroupSocialLinks (groupId, jar) {
       resolveWithFullResponse: true
     }
   })
-    .then(({ statusCode, body }) => {
-      const { errors, data } = JSON.parse(body)
-      if (statusCode === 200 && data) {
+    .then((res) => {
+      const { data } = JSON.parse(res.body)
+      if (res.statusCode === 200 && data) {
         return data
-      } else if (statusCode === 400 || statusCode === 403 || statusCode === 404) {
-        throw new Error(`${errors[0].message} | groupId: ${groupId}`)
-      } else if (statusCode === 401) {
-        throw new Error(`${errors[0].message} (Are you logged in?) | groupId: ${groupId}`)
       } else {
-        throw new Error(`An unknown error occurred with getGroupSocialLinks() | [${statusCode}] groupId: ${groupId}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/groups/getGroups.js
+++ b/lib/groups/getGroups.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -34,14 +35,7 @@ function getGroups (userId) {
       const failedResponse = (responses[0].statusCode !== 200 || !responses[0].body) // we only check the first request because the second one errors if a primary is not set
 
       if (failedResponse) {
-        const body = responses[0].body || {}
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${responses[0].statusCode} ${errors.join(', ')}`))
-        }
-        reject(new Error('The provided user ID is not valid.'))
+        reject(new RobloxAPIError(responses[0]))
       }
 
       responses = responses.map(r => r.body)

--- a/lib/groups/getJoinRequest.js
+++ b/lib/groups/getJoinRequest.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'userId']
@@ -34,13 +35,7 @@ function getJoinRequest (jar, group, userId) {
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body) || null)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       }).catch(error => reject(error))
   })

--- a/lib/groups/getJoinRequests.js
+++ b/lib/groups/getJoinRequests.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -36,13 +37,7 @@ function getJoinRequests (jar, group, sortOrder, limit, cursor) {
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body))
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
       .catch(error => reject(error))

--- a/lib/groups/getPlayers.js
+++ b/lib/groups/getPlayers.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', ['rolesetId']]
@@ -36,13 +37,7 @@ function getPlayersInRoleOnPage (jar, group, rolesetId, sortOrder, limit, cursor
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body))
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       }).catch(error => reject(error))
   })

--- a/lib/groups/getRankInGroup.js
+++ b/lib/groups/getRankInGroup.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'userId']
@@ -27,18 +28,10 @@ function getRankInGroup (groupId, userId) {
       throw new Error('Group id should be a number')
     }
   }
-  return http({ url: `//groups.roblox.com/v2/users/${userId}/groups/roles`, options: { json: true } }).then((body) => {
-    const error = body.errors && body.errors[0]
+  return http({ url: `//groups.roblox.com/v2/users/${userId}/groups/roles`, options: { json: true, resolveWithFullResponse: true } }).then((res) => {
+    if (res.statusCode !== 200) throw new RobloxAPIError(res)
 
-    if (error) {
-      if (error.message === 'NotFound') {
-        throw new Error('An invalid UserID or GroupID was provided.')
-      } else {
-        throw new Error(error.message)
-      }
-    }
-
-    const groupObject = body.data.find((info) => groupId === info.group.id)
+    const groupObject = res.body.data.find((info) => groupId === info.group.id)
 
     return groupObject ? parseInt(groupObject.role.rank) : 0
   })

--- a/lib/groups/getRankNameInGroup.js
+++ b/lib/groups/getRankNameInGroup.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'userId']
@@ -27,18 +28,9 @@ function getRankNameInGroup (group, userId) {
       throw new Error('Group id should be a number')
     }
   }
-  return http({ url: `//groups.roblox.com/v2/users/${userId}/groups/roles`, options: { json: true } }).then((body) => {
-    const error = body.errors && body.errors[0]
-
-    if (error) {
-      if (error.message === 'NotFound') {
-        throw new Error('An invalid UserID or GroupID was provided.')
-      } else {
-        throw new Error(error.message)
-      }
-    }
-
-    const groupObject = body.data.find((info) => group === info.group.id)
+  return http({ url: `//groups.roblox.com/v2/users/${userId}/groups/roles`, options: { json: true, resolveWithFullResponse: true } }).then((res) => {
+    if (res.statusCode !== 200) throw new RobloxAPIError(res)
+    const groupObject = res.body.data.find((info) => group === info.group.id)
 
     return groupObject ? groupObject.role.name : 'Guest'
   })

--- a/lib/groups/getRolePermissions.js
+++ b/lib/groups/getRolePermissions.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['group', 'rolesetId']
 exports.optional = ['jar']
@@ -32,11 +33,7 @@ function getRolePermissions (group, rolesetId, jar) {
       .then(function (res) {
         const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(responseData)
         }

--- a/lib/groups/getRoles.js
+++ b/lib/groups/getRoles.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -30,11 +31,7 @@ function getRoles (group) {
       .then(function (res) {
         const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           let roles = responseData.roles
           roles = roles.sort((a, b) => a.rank - b.rank)

--- a/lib/groups/getShout.js
+++ b/lib/groups/getShout.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -31,11 +32,8 @@ function getShout (group, jar) {
     return http(httpOpt)
       .then(function (res) {
         const responseData = JSON.parse(res.body)
-        if (res.statusCode === 400) {
-          reject(new Error('The group is invalid or does not exist.'))
-        }
-        if (responseData.shout === null) {
-          reject(new Error('You do not have permissions to view the shout for the group.'))
+        if (res.statusCode !== 400) {
+          reject(new RobloxAPIError(res))
         } else {
           resolve(responseData.shout)
         }

--- a/lib/groups/getWall.js
+++ b/lib/groups/getWall.js
@@ -1,4 +1,5 @@
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 exports.required = ['group']
 exports.optional = ['sortOrder', 'limit', 'cursor', 'jar']
@@ -33,11 +34,7 @@ function getPosts (group, sortOrder, limit, cursor, jar) {
       .then(function (res) {
         const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           responseData.data = responseData.data.map((entry) => {
             entry.created = new Date(entry.created)

--- a/lib/groups/handleJoinRequest.js
+++ b/lib/groups/handleJoinRequest.js
@@ -1,3 +1,5 @@
+const RobloxAPIError = require('../util/apiError.js')
+
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
@@ -36,13 +38,8 @@ function handleJoinRequest (group, userId, accept, jar, xcsrf) {
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve()
         }

--- a/lib/groups/leaveGroup.js
+++ b/lib/groups/leaveGroup.js
@@ -2,6 +2,7 @@
 const http = require('../util/http.js').func
 const getCurrentUser = require('../util/getCurrentUser').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -36,13 +37,8 @@ function leaveGroup (group, jar, xcsrf, userId) {
 
     return http(httpOpt)
       .then(function (res) {
-        const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve()
         }

--- a/lib/groups/setGroupDescription.js
+++ b/lib/groups/setGroupDescription.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -41,15 +42,7 @@ function changeGroupDesc (group, description = '', jar, xcsrf) {
         if (res.statusCode === 200) {
           resolve(res.body)
         } else {
-          const body = res.body || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} ${res.body}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/groups/setGroupName.js
+++ b/lib/groups/setGroupName.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'name']
@@ -42,15 +43,7 @@ function changeGroupName (group, name, jar, xcsrf) {
         if (res.statusCode === 200) {
           resolve(res.body)
         } else {
-          const body = res.body || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} ${res.body}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/groups/setRank.js
+++ b/lib/groups/setRank.js
@@ -2,6 +2,7 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
 const getRole = require('./getRole.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group', 'target', 'rank']
@@ -44,13 +45,7 @@ function setRank (jar, xcsrf, group, target, role) {
         if (res.statusCode === 200) {
           resolve(role)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       }).catch(error => reject(error))
   })

--- a/lib/groups/shout.js
+++ b/lib/groups/shout.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -41,15 +42,7 @@ function shoutOnGroup (group, message = '', jar, xcsrf) {
         if (res.statusCode === 200) {
           resolve(res.body)
         } else {
-          const body = res.body || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} ${res.body}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       }).catch(error => reject(error))
   })

--- a/lib/inventory/getOwnership.js
+++ b/lib/inventory/getOwnership.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId', 'itemTargetId']
@@ -34,15 +35,7 @@ function getOwnership (userId, itemTargetId, itemType) {
           const body = JSON.parse(res.body)
           resolve(body.data.length > 0)
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          } else {
-            reject(new Error(`${res.statusCode} ${res.body}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/premiumfeatures/getPremium.js
+++ b/lib/premiumfeatures/getPremium.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -33,13 +34,7 @@ function getPremium (jar, userId) {
         if (res.statusCode === 200) {
           resolve(res.body === 'true')
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/presence/getPresences.js
+++ b/lib/presence/getPresences.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userIds']
@@ -41,11 +42,7 @@ function getPresences (userIds, jar, xcsrf) {
       .then(function (res) {
         const responseData = JSON.parse(res.body)
         if (res.statusCode !== 200) {
-          let error = 'An unknown error has occurred.'
-          if (responseData && responseData.errors) {
-            error = responseData.errors.map((e) => e.message).join('\n')
-          }
-          reject(new Error(error))
+          reject(new RobloxAPIError(res))
         } else {
           resolve(responseData)
         }

--- a/lib/privatemessages/getMessages.js
+++ b/lib/privatemessages/getMessages.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 // Args
 exports.required = []
 exports.optional = ['pageNumber', 'pageSize', 'messageTab', 'jar']
@@ -34,13 +35,7 @@ function getMessages (jar, pageNumber, pageSize, messageTab) {
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body))
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/privatemessages/message.js
+++ b/lib/privatemessages/message.js
@@ -4,6 +4,7 @@ const queue = require('../internal/queue.js')
 const getGeneralToken = require('../util/getGeneralToken.js').func
 const getHash = require('../util/getHash.js').func
 const getSenderId = require('../util/getSenderUserId.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['recipient', 'subject', 'body']
@@ -53,13 +54,7 @@ function message (jar, token, senderId, recipient, subject, body, replyMessageId
         if (res.statusCode === 200) {
           resolve(JSON.parse(res.body))
         } else {
-          const body = JSON.parse(res.body) || {}
-          if (body.errors && body.errors.length > 0) {
-            const errors = body.errors.map((e) => {
-              return e.message
-            })
-            reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-          }
+          reject(new RobloxAPIError(res))
         }
       })
   })

--- a/lib/thumbnails/getLogo.js
+++ b/lib/thumbnails/getLogo.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['group']
@@ -30,22 +31,17 @@ function getLogo (group, size, circular, format) {
         format: format || 'Png',
         isCircular: circular
       },
-      json: true
+      json: true,
+      resolveWithFullResponse: true
     }
   }
   return http(httpOpt)
-    .then(function (body) {
-      const error = body.errors && body.errors[0]
-
-      if (error) {
-        if (error.message === 'NotFound') {
-          throw new Error('An invalid UserID or GroupID was provided.')
-        } else {
-          throw new Error(error.message)
-        }
+    .then(function (res) {
+      if (res.statusCode !== 200) {
+        throw new RobloxAPIError(res)
       }
 
-      const thumbnailData = body.data[0]
+      const thumbnailData = res.body.data[0]
 
       if (thumbnailData.state !== 'Completed') {
         throw new Error('The requested image has not been approved. Status: ' + thumbnailData.state)

--- a/lib/thumbnails/getPlayerThumbnail.js
+++ b/lib/thumbnails/getPlayerThumbnail.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const { thumbnail: settings } = require('../../settings.json')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userIds']
@@ -85,9 +86,9 @@ function getPlayerThumbnail (userIds, size, format = 'png', isCircular = false, 
       followRedirect: true
     }
   })
-    .then(async ({ statusCode, body }) => {
-      let { data, errors } = JSON.parse(body)
-      if (statusCode === 200) {
+    .then(async (res) => {
+      let { data } = JSON.parse(res.body)
+      if (res.statusCode === 200) {
         if (retryCount > 0) {
           const pendingThumbnails = data.filter(obj => { return obj.state === 'Pending' }).map(obj => obj.targetId) // Get 'Pending' thumbnails as array of userIds
           if (pendingThumbnails.length > 0) {
@@ -104,10 +105,8 @@ function getPlayerThumbnail (userIds, size, format = 'png', isCircular = false, 
           return obj
         })
         return data
-      } else if (statusCode === 400) {
-        throw new Error(`Error Code ${errors.code}: ${errors.message} | endpoint: ${endpoint}, userIds: ${userIds.join(',')}, size: ${size}, isCircular: ${!!isCircular}`)
       } else {
-        throw new Error(`An unknown error occurred with getPlayerThumbnail() | endpoint: ${endpoint}, userIds: ${userIds.join(',')}, size: ${size}, isCircular: ${!!isCircular}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/thumbnails/getThumbnails.js
+++ b/lib/thumbnails/getThumbnails.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const { thumbnail: settings } = require('../../settings.json')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['thumbnailRequests']
@@ -58,9 +59,9 @@ function getThumbnails (requests, retryCount = settings.maxRetries) {
       followRedirect: true
     }
   })
-    .then(async ({ statusCode, body }) => {
-      let { data, errors } = body
-      if (statusCode === 200) {
+    .then(async (res) => {
+      let { data } = res.body
+      if (res.statusCode === 200) {
         if (retryCount > 0) {
           const pendingThumbnails = data.filter(obj => { return obj.state === 'Pending' }).map(obj => obj.targetId) // Get 'Pending' thumbnails as array of userIds
           if (pendingThumbnails.length > 0) {
@@ -76,10 +77,8 @@ function getThumbnails (requests, retryCount = settings.maxRetries) {
           return obj
         })
         return data
-      } else if (statusCode === 400) {
-        throw new Error(`Error Code ${errors.code}: ${errors.message} | requests: ${JSON.stringify(requests)}`)
       } else {
-        throw new Error(`An unknown error occurred with getThumbnails() | requests: ${JSON.stringify(requests)}`)
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/trades/acceptTrade.js
+++ b/lib/trades/acceptTrade.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['tradeId']
@@ -36,14 +37,7 @@ function acceptTrade (tradeId, jar, xcsrf) {
       if (res.statusCode === 200) {
         resolve()
       } else {
-        const body = JSON.parse(res.body) || {}
-
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/trades/canTradeWith.js
+++ b/lib/trades/canTradeWith.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -31,13 +32,7 @@ function canTradeWith (jar, userId) {
       if (res.statusCode === 200) {
         resolve(JSON.parse(res.body))
       } else {
-        const body = JSON.parse(res.body) || {}
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/trades/counterTrade.js
+++ b/lib/trades/counterTrade.js
@@ -2,6 +2,7 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
 const getCurrentUser = require('../util/getCurrentUser.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['tradeId', 'targetUserId', 'sendingOffer', 'receivingOffer']
@@ -59,14 +60,7 @@ function counterTrade (tradeId, targetUserId, sendingOffer, receivingOffer, jar,
       if (res.statusCode === 200) {
         resolve(JSON.parse(res.body))
       } else {
-        const body = JSON.parse(res.body) || {}
-
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/trades/declineTrade.js
+++ b/lib/trades/declineTrade.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['tradeId']
@@ -36,14 +37,7 @@ function declineTrade (tradeId, jar, xcsrf) {
       if (res.statusCode === 200) {
         resolve()
       } else {
-        const body = JSON.parse(res.body) || {}
-
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/trades/getTradeInfo.js
+++ b/lib/trades/getTradeInfo.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['tradeId']
@@ -35,13 +36,7 @@ const getTradeInfo = (jar, tradeId) => {
 
         resolve(body)
       } else {
-        const body = JSON.parse(res.body) || {}
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/trades/sendTrade.js
+++ b/lib/trades/sendTrade.js
@@ -2,6 +2,7 @@
 const http = require('../util/http.js').func
 const getGeneralToken = require('../util/getGeneralToken.js').func
 const getCurrentUser = require('../util/getCurrentUser.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['targetUserId', 'sendingOffer', 'receivingOffer']
@@ -57,14 +58,7 @@ function sendTrade (targetUserId, sendingOffer, receivingOffer, jar, xcsrf, logg
       if (res.statusCode === 200) {
         resolve(JSON.parse(res.body))
       } else {
-        const body = JSON.parse(res.body) || {}
-
-        if (body.errors && body.errors.length > 0) {
-          const errors = body.errors.map((e) => {
-            return e.message
-          })
-          reject(new Error(`${res.statusCode} ${errors.join(', ')}`))
-        }
+        reject(new RobloxAPIError(res))
       }
     }).catch(error => reject(error))
   })

--- a/lib/users/getBlurb.js
+++ b/lib/users/getBlurb.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -30,7 +31,7 @@ exports.func = function (args) {
         const parsedBody = JSON.parse(res.body)
         return parsedBody.description
       } else {
-        throw new Error('User does not exist')
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/users/getIdFromUsername.js
+++ b/lib/users/getIdFromUsername.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['username']
@@ -27,12 +28,14 @@ function getIdFromUsername (usernames) {
       json: {
         usernames,
         excludeBannedUsers: false
-      }
+      },
+      resolveWithFullResponse: true
     }
   }
   return http(httpOpt)
-    .then(function (body) {
-      const data = body.data
+    .then(function (res) {
+      if (res.statusCode !== 200) throw new RobloxAPIError(res)
+      const data = res.body.data
 
       let results = usernames.map((username) => {
         return data.find((result) => result.requestedUsername === username)

--- a/lib/users/getUserInfo.js
+++ b/lib/users/getUserInfo.js
@@ -1,5 +1,6 @@
 // Includes
 const http = require('../util/http.js').func
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['userId']
@@ -25,7 +26,7 @@ exports.func = function (args) {
   }
 
   return http(httpOpt).then(function (res) {
-    if (res.statusCode !== 200) { throw new Error(`Failed to fetch user information: ${res.body.errors?.join(', ')}`) }
+    if (res.statusCode !== 200) { throw new RobloxAPIError(res) }
 
     res.body.created = new Date(res.body.created)
 

--- a/lib/users/getUsernameFromId.js
+++ b/lib/users/getUsernameFromId.js
@@ -1,6 +1,7 @@
 // Includes
 const http = require('../util/http.js').func
 const cache = require('../cache')
+const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['id']
@@ -31,7 +32,7 @@ function getUsernameFromId (id) {
         const json = JSON.parse(res.body)
         return json.name
       } else {
-        throw new Error('User does not exist')
+        throw new RobloxAPIError(res)
       }
     })
 }

--- a/lib/util/apiError.js
+++ b/lib/util/apiError.js
@@ -38,4 +38,4 @@ function getResponseBody (data) {
   }
 }
 
-export default RobloxAPIError
+module.exports = RobloxAPIError


### PR DESCRIPTION
Currently draft because I may not be totally done but am open to help if someone is willing.

Does not include:
- Anything involving SignalR (will possibly make something else for this)
- `upload[thing]` methods since those need new endpoints
- `buy()` since it doesn't work anymore, requires multiple endpoints + 2fa, and is generally abused [eligible for removal]
- `configureItem` and `canManage` since those also need new endpoints