### PR TITLE
Fix CSRF token retry

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -83,32 +83,22 @@ exports.func = function (args) {
   }
   return http(args.url, opt).then(function (res) {
     if (opt && opt.headers && opt.headers['X-CSRF-TOKEN']) {
-      if (res.statusCode === 403) {
-        let message
+      if (res.statusCode === 403 && res.headers['X-CSRF-TOKEN']) {
+        depth++
 
-        try {
-          message = typeof res.body === 'string' ? JSON.parse(res.body).message : res.body.message
-        } catch (_) {
-          // Roblox didn't send back a properly formed json object
+        if (depth >= 3) {
+          throw new Error('Tried ' + depth + ' times and could not refresh XCSRF token successfully')
         }
 
-        if (message === 'XSRF Token Validation Failed' || message === 'Token Validation Failed') {
-          depth++
+        const token = res.headers['x-csrf-token']
 
-          if (depth >= 3) {
-            throw new Error('Tried ' + depth + ' times and could not refresh XCSRF token successfully')
-          }
-
-          const token = res.headers['x-csrf-token']
-
-          if (token) {
-            opt.headers['X-CSRF-TOKEN'] = token
-            opt.jar = jar
-            args.depth = depth + 1
-            return exports.func(args)
-          } else {
-            throw new Error('Could not refresh X-CSRF-TOKEN')
-          }
+        if (token) {
+          opt.headers['X-CSRF-TOKEN'] = token
+          opt.jar = jar
+          args.depth = depth + 1
+          return exports.func(args)
+        } else {
+          throw new Error('Could not refresh X-CSRF-TOKEN')
         }
       } else {
         if (depth > 0) {

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -84,10 +84,8 @@ exports.func = function (args) {
   return http(args.url, opt).then(function (res) {
     if (opt && opt.headers && opt.headers['X-CSRF-TOKEN']) {
       if (res.statusCode === 403 && res.headers['X-CSRF-TOKEN']) {
-        depth++
-
-        if (depth >= 3) {
-          throw new Error('Tried ' + depth + ' times and could not refresh XCSRF token successfully')
+        if (depth >= 2) {
+          throw new Error('Tried ' + (depth + 1) + ' times and could not refresh XCSRF token successfully')
         }
 
         const token = res.headers['x-csrf-token']

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -71,7 +71,7 @@ exports.func = function (args) {
     opt.jar = { session: opt.jar }
   }
   const jar = opt.jar
-  let depth = args.depth || 0
+  const depth = args.depth || 0
   const full = opt.resolveWithFullResponse || false
   opt.resolveWithFullResponse = true
   const follow = opt.followRedirect === undefined || opt.followRedirect


### PR DESCRIPTION
Roblox changed the wording of the token validation error, removing the message check entirely is the better choice since there is no guarantee that they won't do it again (and was a bad idea to begin with).