### PR TITLE
Normalize HTTP headers

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -87,7 +87,7 @@ exports.func = function (args) {
     return follow
   }
   return http(args.url, opt).then(function (res) {
-    if (res.statusCode === 403 && res.headers['x-csrf-token'] && opt.headers['x-csrf-token']) {
+    if (res.statusCode === 403 && res.headers['x-csrf-token'] && Object.hasOwn(opt.headers ?? {}, 'x-csrf-token')) {
       if (depth >= 2) {
         throw new Error('Tried ' + (depth + 1) + ' times and could not refresh XCSRF token successfully')
       }

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -87,26 +87,24 @@ exports.func = function (args) {
     return follow
   }
   return http(args.url, opt).then(function (res) {
-    if (opt && opt.headers && opt.headers['X-CSRF-TOKEN']) {
-      if (res.statusCode === 403 && res.headers['X-CSRF-TOKEN']) {
-        if (depth >= 2) {
-          throw new Error('Tried ' + (depth + 1) + ' times and could not refresh XCSRF token successfully')
-        }
+    if (res.statusCode === 403 && res.headers['x-csrf-token'] && opt.headers['x-csrf-token']) {
+      if (depth >= 2) {
+        throw new Error('Tried ' + (depth + 1) + ' times and could not refresh XCSRF token successfully')
+      }
 
-        const token = res.headers['x-csrf-token']
+      const token = res.headers['x-csrf-token']
 
-        if (token) {
-          opt.headers['X-CSRF-TOKEN'] = token
-          opt.jar = jar
-          args.depth = depth + 1
-          return exports.func(args)
-        } else {
-          throw new Error('Could not refresh X-CSRF-TOKEN')
-        }
+      if (token) {
+        opt.headers['x-csrf-token'] = token
+        opt.jar = jar
+        args.depth = depth + 1
+        return exports.func(args)
       } else {
-        if (depth > 0) {
-          cache.add(options.cache, 'XCSRF', getHash({ jar }), opt.headers['X-CSRF-TOKEN'])
-        }
+        throw new Error('Could not refresh X-CSRF-TOKEN')
+      }
+    } else {
+      if (depth > 0) {
+        cache.add(options.cache, 'XCSRF', getHash({ jar }), opt.headers['x-csrf-token'])
       }
     }
     if (res.statusCode === 302 && !args.ignoreLoginError && res.headers.location && (res.headers.location.startsWith('https://www.roblox.com/newlogin') || res.headers.location.startsWith('/Login/Default.aspx'))) {

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -37,6 +37,11 @@ request = request.defaults({
 **/
 
 function http (url, opt) {
+  if (opt?.headers) {
+    opt.headers = Object.fromEntries(
+      Object.entries(opt.headers).map(([k, v]) => [k.toLowerCase(), v])
+    )
+  }
   if (opt && !opt.jar && Object.keys(opt).indexOf('jar') > -1) {
     opt.jar = options.jar
   }


### PR DESCRIPTION
This took an embarrassingly long time to figure out, but at some point, the response headers object stopped being case-insensitive.

It is preferable that we normalize all request headers in the http method to be lowercase (the response headers are always lowercase) so that these issues do not occur in the future by way of someone using a lowercase header name in a method.