### PR TITLE
Request forwarding for CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Run tests
         env:
+          API_KEY: ${{ secrets.API_KEY }}
           COOKIE: ${{ secrets.COOKIE }}
           COOKIE_2: ${{ secrets.COOKIE_2 }}
           FORWARDER_HOSTNAME: ${{ vars.forwarder_hostname }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,27 +6,42 @@ on:
 
 jobs:
   test:
+    permissions:
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: Install yarn
-        run: npm install -g yarn
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Lint lib/
         run: yarn lint
+
+      - id: auth
+        name: Generate ID Token
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: id_token
+          workload_identity_provider: ${{ vars.workload_identity_provider }}
+          service_account: ${{ vars.service_account }}
+          id_token_audience: "https://${{ vars.forwarder_hostname }}"
+          id_token_include_email: true
+
       - name: Run tests
         env:
           COOKIE: ${{ secrets.COOKIE }}
           COOKIE_2: ${{ secrets.COOKIE_2 }}
+          ID_TOKEN: ${{ steps.auth.outputs.id_token }}
         run: yarn test
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           COOKIE: ${{ secrets.COOKIE }}
           COOKIE_2: ${{ secrets.COOKIE_2 }}
+          FORWARDER_HOSTNAME: ${{ vars.forwarder_hostname }}
           ID_TOKEN: ${{ steps.auth.outputs.id_token }}
         run: yarn test
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -67,8 +67,8 @@ function http (url, opt) {
     const { hostname } = urlObj
 
     opt.headers["Destination-Host"] = hostname
-    opt.headers["x-serverless-authorization"] = process.env.ID_TOKEN
-    urlObj.hostname = process.env.FORWARDER_URL
+    opt.headers["x-serverless-authorization"] = `Bearer ${process.env.ID_TOKEN}`
+    urlObj.hostname = process.env.FORWARDER_HOSTNAME
     url = urlObj.href
   }
   return request(url, opt)

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -62,6 +62,14 @@ function http (url, opt) {
   if (url.indexOf('http') !== 0) {
     url = 'https:' + url
   }
+
+  /*
+    In CI, actions does not allow us to use a static ip address (nor guarantees any particular location)
+    This is a problem as Roblox locks sessions to a particular region
+    Therefore, we intercept the request during testing and send it to the forwarder (which has a static ip address), the Roblox hostname is set as the Destination-Host header
+    The ID token is for Google Cloud and allows authenticating with the Cloud Run service that acts as our forwarder
+    Requests without headers do not go through the forwarder as they are unauthenticated and do not need forwarding
+  */
   if (process?.env.CI && process.env.FORWARDER_HOSTNAME && opt.headers) {
     const urlObj = new URL(url)
     const { hostname } = urlObj

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -62,7 +62,7 @@ function http (url, opt) {
   if (url.indexOf('http') !== 0) {
     url = 'https:' + url
   }
-  if (process?.env.CI && process.env.FORWARDER_URL) {
+  if (process?.env.CI && process.env.FORWARDER_HOSTNAME) {
     const urlObj = new URL(url)
     const { hostname } = urlObj
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -66,8 +66,8 @@ function http (url, opt) {
     const urlObj = new URL(url)
     const { hostname } = urlObj
 
-    opt.headers["Destination-Host"] = hostname
-    opt.headers["x-serverless-authorization"] = `Bearer ${process.env.ID_TOKEN}`
+    opt.headers['Destination-Host'] = hostname
+    opt.headers['x-serverless-authorization'] = `Bearer ${process.env.ID_TOKEN}`
     urlObj.hostname = process.env.FORWARDER_HOSTNAME
     url = urlObj.href
   }

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -47,6 +47,16 @@ function http (url, opt) {
     opt.headers.cookie = '.ROBLOSECURITY=' + opt.jar.session + ';'
     opt.headers['x-api-key'] = opt.jar.apiKey
     opt.jar = null
+
+    if (process?.env.CI && process.env.FORWARDER_HOSTNAME) {
+      const urlObj = new URL(url)
+      const { hostname } = urlObj
+
+      opt.headers['Destination-Host'] = hostname
+      opt.headers['x-serverless-authorization'] = `Bearer ${process.env.ID_TOKEN}`
+      urlObj.hostname = process.env.FORWARDER_HOSTNAME
+      url = urlObj.href
+    }
   }
   if (opt && opt.verification) {
     if (!opt.headers) {
@@ -61,15 +71,6 @@ function http (url, opt) {
   }
   if (url.indexOf('http') !== 0) {
     url = 'https:' + url
-  }
-  if (process?.env.CI && process.env.FORWARDER_HOSTNAME) {
-    const urlObj = new URL(url)
-    const { hostname } = urlObj
-
-    opt.headers['Destination-Host'] = hostname
-    opt.headers['x-serverless-authorization'] = `Bearer ${process.env.ID_TOKEN}`
-    urlObj.hostname = process.env.FORWARDER_HOSTNAME
-    url = urlObj.href
   }
   return request(url, opt)
 }

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -62,6 +62,15 @@ function http (url, opt) {
   if (url.indexOf('http') !== 0) {
     url = 'https:' + url
   }
+  if (process?.env.CI && process.env.FORWARDER_URL) {
+    const urlObj = new URL(url)
+    const { hostname } = urlObj
+
+    opt.headers["Destination-Host"] = hostname
+    opt.headers["x-serverless-authorization"] = process.env.ID_TOKEN
+    urlObj.hostname = process.env.FORWARDER_URL
+    url = urlObj.href
+  }
   return request(url, opt)
 }
 

--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -47,16 +47,6 @@ function http (url, opt) {
     opt.headers.cookie = '.ROBLOSECURITY=' + opt.jar.session + ';'
     opt.headers['x-api-key'] = opt.jar.apiKey
     opt.jar = null
-
-    if (process?.env.CI && process.env.FORWARDER_HOSTNAME) {
-      const urlObj = new URL(url)
-      const { hostname } = urlObj
-
-      opt.headers['Destination-Host'] = hostname
-      opt.headers['x-serverless-authorization'] = `Bearer ${process.env.ID_TOKEN}`
-      urlObj.hostname = process.env.FORWARDER_HOSTNAME
-      url = urlObj.href
-    }
   }
   if (opt && opt.verification) {
     if (!opt.headers) {
@@ -71,6 +61,15 @@ function http (url, opt) {
   }
   if (url.indexOf('http') !== 0) {
     url = 'https:' + url
+  }
+  if (process?.env.CI && process.env.FORWARDER_HOSTNAME && opt.headers) {
+    const urlObj = new URL(url)
+    const { hostname } = urlObj
+
+    opt.headers['Destination-Host'] = hostname
+    opt.headers['x-serverless-authorization'] = `Bearer ${process.env.ID_TOKEN}`
+    urlObj.hostname = process.env.FORWARDER_HOSTNAME
+    url = urlObj.href
   }
   return request(url, opt)
 }


### PR DESCRIPTION
Right now we cannot actually test anything requiring a cookie because of region locking (which is most of this library). My solution is to use a cloud run service with direct vpc egress (which allows us to utilize a single static ip address for all requests). This would utilize workload identity federation which avoids the need for any additional secrets (by using the oidc token provided by actions).

Some actions updates were also included (and I verified they continued to work)