### PR TITLE
Support caching the value `0` (Fixes #864)

### DIFF
--- a/lib/cache/addIf.js
+++ b/lib/cache/addIf.js
@@ -7,7 +7,7 @@ module.exports = function (cache, type, index, callbacks) {
   const got = get(cache, type, index)
   const item = got[0]
   const refresh = got[1]
-  if (item) {
+  if (item != null) {
     callbacks.done(item)
     if (refresh) {
       const group = cache[type]


### PR DESCRIPTION
Simple one-line change to fix a bug when the value `0` is cached.