### PR TITLE
Fix: Correct reupload logic for existing animation assets

### DIFF
--- a/lib/asset/uploadAnimation.js
+++ b/lib/asset/uploadAnimation.js
@@ -33,71 +33,80 @@ exports.optional = ['itemOptions', 'assetId', 'jar']
 **/
 
 // Define
-function upload (data, itemOptions, assetId, jar, token) {
-  const httpOpt = {
-    url: assetId ? `//www.roblox.com/ide/publish/uploadexistinganimation?assetID=${assetId}&isGamesAsset=False` : '//www.roblox.com/ide/publish/uploadnewanimation?AllID=1',
-    options: {
-      resolveWithFullResponse: true,
-      method: 'POST',
-      jar,
-      body: data,
-      headers: {
-        'X-CSRF-TOKEN': token,
-        'Content-Type': 'application/xml',
-        'User-Agent': 'RobloxStudio/WinInet RobloxApp/0.483.1.425021 (GlobalDist; RobloxDirectDownload)'
+function upload(data, itemOptions, assetId, jar, token) {
+  // Helper function to perform the actual upload
+  function performUpload(uploadData, options) {
+    if (!options) {
+      throw new Error('ItemOptions is required for uploads.')
+    }
+
+    const copyLocked = options.copyLocked
+    const allowComments = options.allowComments
+
+    const uploadUrl = 'https://www.roblox.com/ide/publish/uploadnewanimation?' +
+      'AllID=1&assetTypeName=Animation&isGamesAsset=False&' +
+      'name=' + encodeURIComponent(options.name || 'Animation') +
+      '&description=' + encodeURIComponent(options.description || '') +
+      '&ispublic=' + (copyLocked != null ? !copyLocked : false) +
+      '&allowComments=' + (allowComments != null ? allowComments : true) +
+      '&groupId=' + (options.groupId || '')
+
+    const httpOpt = {
+      url: uploadUrl,
+      options: {
+        resolveWithFullResponse: true,
+        method: 'POST',
+        jar,
+        body: uploadData,
+        headers: {
+          'X-CSRF-TOKEN': token,
+          'Content-Type': 'application/xml',
+          'User-Agent': 'RobloxStudio/WinInet RobloxApp/0.483.1.425021 (GlobalDist; RobloxDirectDownload)'
+        }
       }
     }
-  }
 
-  if (!assetId && itemOptions) {
-    const copyLocked = itemOptions.copyLocked
-    const allowComments = itemOptions.allowComments
-    httpOpt.url += '&assetTypeName=Animation&genreTypeId=1&name=' +
-      itemOptions.name +
-      '&description=' +
-      (itemOptions.description || '') +
-      '&ispublic=' +
-      (copyLocked != null ? !copyLocked : false) +
-      '&allowComments=' +
-      (allowComments != null ? allowComments : true) +
-      '&groupId=' +
-      (itemOptions.groupId || '')
-  } else if (!assetId) {
-    throw new Error('ItemOptions is required for new assets.')
-  }
-
-  return http(httpOpt)
-    .then(function (res) {
-      if (res.statusCode === 200) {
-        const resultId = assetId || Number(res.body)
-
-        if (assetId && itemOptions) {
-          const copyLocked = itemOptions.copyLocked
-          const allowComments = itemOptions.allowComments
-
-          return configureItem({
-            id: resultId,
-            name: itemOptions.name,
-            description: itemOptions.description,
-            enableComments: (allowComments != null ? allowComments : true),
-            sellForRobux: (copyLocked != null ? !copyLocked : false)
-          }).then(function () {
-            return resultId
-          })
+    return http(httpOpt)
+      .then(function(res) {
+        if (res.statusCode === 200) {
+          return Number(res.body)
         } else {
-          return resultId
+          throw new Error('Animation upload failed, confirm that all item options, asset options, and upload data are valid.')
         }
-      } else {
-        throw new Error('Animation upload failed, confirm that all item options, asset options, and upload data are valid.')
+      })
+  }
+
+  // If updating existing animation, download current data first
+  if (assetId) {
+    const downloadOpt = {
+      url: `https://assetdelivery.roblox.com/v1/asset/?id=${assetId}`,
+      options: {
+        method: 'GET',
+        jar,
+        encoding: null // Important: get raw binary data
       }
-    })
+    }
+
+    return http(downloadOpt)
+      .then(function(downloadRes) {
+        if (downloadRes.statusCode !== 200) {
+          throw new Error(`Failed to download existing asset ${assetId}`)
+        }
+
+        // Use downloaded data and upload with new parameters
+        return performUpload(downloadRes.body, itemOptions)
+      })
+  } else {
+    // Upload new animation with provided data
+    return performUpload(data, itemOptions)
+  }
 }
 
-exports.func = function (args) {
+exports.func = function(args) {
   const jar = args.jar
   return getGeneralToken({
     jar
-  }).then(function (token) {
+  }).then(function(token) {
     return upload(args.data, args.itemOptions, args.assetId, args.jar, token)
   })
 }


### PR DESCRIPTION
### Fix for issue #842

This PR corrects the reupload logic for overwriting an existing animation. Previously, the logic used a decapitated API to replace an existing. 

# ✅ The New Approach
- Downloads existing animation data from "assetdelivery.roblox.com/v1/asset/" instead of using a deleted API
- Uses the Upload API for both overwriting and creating Animations.
- Wraps all uploading under helper function `performUpload()` 

# Disclaimer
I fixed this in python and had the final JavaScript implementation translated with the help of AI. So please test this code and make any changes you need. (Ive never coded in javascript)

 Im merely just showing another way of doing this with the `roblox.com/ide/publish/uploadexistinganimation` being gone.
