### PR TITLE
fix: Update endpoint for getGamePasses

### DIFF
--- a/lib/games/getGamePasses.js
+++ b/lib/games/getGamePasses.js
@@ -4,7 +4,6 @@ const RobloxAPIError = require('../util/apiError.js')
 
 // Args
 exports.required = ['universeId']
-exports.optional = ['limit']
 
 // Docs
 /**
@@ -12,14 +11,13 @@ exports.optional = ['limit']
  * @category Game
  * @alias getGamePasses
  * @param {number} universeId - The id of the universe.
- * @param {Limit=} limit - The max number of game passes to return.
  * @returns {Promise<GamePassData[]>}
  * @example const noblox = require("noblox.js")
  * const gamePasses = await noblox.getGamePasses(1686885941)
 **/
 
 // Define
-const getGamePasses = async (universeId, limit) => {
+const getGamePasses = async (universeId) => {
   const res = await http({
     url: `//apis.roblox.com/game-passes/v1/universes/${universeId}/game-passes?passView=Full`,
     options: {
@@ -35,9 +33,9 @@ const getGamePasses = async (universeId, limit) => {
   return res.body.gamePasses
 }
 
-exports.func = function ({ universeId, limit }) {
+exports.func = function ({ universeId }) {
   if (isNaN(universeId)) {
     throw new Error('The provided universe ID is not a number.')
   }
-  return getGamePasses(universeId, limit)
+  return getGamePasses(universeId)
 }


### PR DESCRIPTION
Resolves #868 

Remove pagination since Roblox now allows fetching every gamepass (as it seems open cloud does not mandate pagination on most endpoints), should not be a breaking change as the limit argument will be ignored if passed.