### PR TITLE
Update deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -37,19 +37,19 @@ jobs:
     steps:
       - name: Checkout code with ADMIN_TOKEN
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
            token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Checkout code
         if: github.event.pull_request.head.repo.full_name != github.repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
       - name: Set up node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -60,7 +60,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: yarn-deps-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Bump actions/checkout from v2 to v4, actions/setup-node from v1 to v4, and actions/cache from v1 to v4 across doc-publish and npmpublish workflows.